### PR TITLE
Feat/login v2

### DIFF
--- a/back/build.gradle
+++ b/back/build.gradle
@@ -30,6 +30,7 @@ dependencies {
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'com.h2database:h2'
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'

--- a/back/build.gradle
+++ b/back/build.gradle
@@ -48,6 +48,11 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+    
+    //이메일 인증
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
+
+    
 
 }
 

--- a/back/src/main/java/org/kosa/tripTalk/OAuth2/OAuth2LoginSuccessHandler.java
+++ b/back/src/main/java/org/kosa/tripTalk/OAuth2/OAuth2LoginSuccessHandler.java
@@ -1,0 +1,82 @@
+package org.kosa.tripTalk.OAuth2;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.kosa.tripTalk.jwt.JwtUtil;
+
+import org.kosa.tripTalk.user.User;
+import org.kosa.tripTalk.user.User.Role;
+import org.kosa.tripTalk.user.UserRepository;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
+  
+  private final JwtUtil jwtUtil;
+  private final UserRepository userRepository;
+
+  @Override
+  public void onAuthenticationSuccess(HttpServletRequest request,
+                                      HttpServletResponse response,
+                                      Authentication authentication) throws IOException {
+
+      OAuth2User oAuth2User = (OAuth2User) authentication.getPrincipal();
+      
+      // 1. 카카오 ID 추출
+      String kakaoId = oAuth2User.getAttribute("id").toString(); // 소셜 고유 ID(socialId)
+      String userId = "kakao_" + kakaoId;
+
+
+      // 카카오 사용자 닉네임 추출
+      Map<String, Object> properties = oAuth2User.getAttribute("properties");
+      String nickname = (properties != null) ? properties.get("nickname").toString() : "카카오사용자";
+
+      // DB에서 사용자 조회, 없으면 새로 생성
+      User user = userRepository.findBySocialId(kakaoId)
+          .orElseGet(() -> {
+              return userRepository.save(User.builder()
+                  .userId(userId)
+                  .socialId(kakaoId)
+                  .email(null) // 이메일 받아올 경우 설정
+                  .name(nickname)
+                  .nickname(userId) // 임시 nickname
+                  .password("") // 소셜은 비밀번호 미사용
+                  .role(User.Role.USER)
+                  .phone("000-0000-0000") // 임시 처리, 나중에 수집
+                  .loginType("KAKAO")
+                  .emailVerified(true)
+                  .build());
+          });
+
+      // JWT 토큰 생성
+      String accessToken = jwtUtil.generateAccessToken(user.getUserId(), user.getRole());
+      String refreshToken = jwtUtil.generateRefreshToken(user.getUserId());
+
+      //리프레시 토큰 쿠키 저장
+      Cookie refreshTokenCookie = new Cookie("refreshToken", refreshToken);
+      refreshTokenCookie.setPath("/");
+      refreshTokenCookie.setHttpOnly(true);
+      refreshTokenCookie.setSecure(false);
+      refreshTokenCookie.setMaxAge(60 * 60 * 24 * 7); // 일주일
+      response.addCookie(refreshTokenCookie);
+
+      //엑세스 토큰 쿠키 저장
+      Cookie accessTokenCookie = new Cookie("accessToken", accessToken);
+      accessTokenCookie.setPath("/");
+      accessTokenCookie.setHttpOnly(true); // JS 접근 차단
+      accessTokenCookie.setSecure(false);  // 배포 시 true (HTTPS)
+      accessTokenCookie.setMaxAge(60 * 60); // 1시간
+      response.addCookie(accessTokenCookie);
+
+      response.sendRedirect("http://localhost:3000/oauth2");
+  }
+}

--- a/back/src/main/java/org/kosa/tripTalk/SecurityConfig.java
+++ b/back/src/main/java/org/kosa/tripTalk/SecurityConfig.java
@@ -28,7 +28,12 @@ public class SecurityConfig {
               .httpBasic(AbstractHttpConfigurer::disable) //httpBasic 인증 비활성화
               .formLogin(AbstractHttpConfigurer::disable) //스프링 시큐리티 기본 로그인 폼 비활성화
               .authorizeHttpRequests((authorize) -> authorize //요청경로 접근제어
-                      .requestMatchers("/api/user/register", "/", "/api/user/login").permitAll()
+                      .requestMatchers(
+                          "/api/user/register",
+                          "/",
+                          "/api/user/login",
+                          "/email/verify"
+                      ).permitAll()
                       .anyRequest().authenticated())
               .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
               // 폼 로그인은 현재 사용하지 않음         

--- a/back/src/main/java/org/kosa/tripTalk/SecurityConfig.java
+++ b/back/src/main/java/org/kosa/tripTalk/SecurityConfig.java
@@ -1,7 +1,9 @@
 package org.kosa.tripTalk;
 
+import org.kosa.tripTalk.OAuth2.OAuth2LoginSuccessHandler;
 import org.kosa.tripTalk.jwt.JwtAuthenticationFilter;
 import org.kosa.tripTalk.jwt.JwtUtil;
+import org.kosa.tripTalk.user.UserRepository;
 import org.kosa.tripTalk.user.UserService;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -20,6 +22,7 @@ import lombok.RequiredArgsConstructor;
 public class SecurityConfig {
 
   private final JwtUtil jwtUtil;
+  private final UserRepository userRepository;
   
   //스프링 시큐리티 설정
   @Bean
@@ -31,10 +34,14 @@ public class SecurityConfig {
                       .requestMatchers(
                           "/api/user/register",
                           "/",
-                          "/api/user/login",
+                          "/api/user/login/**",
+                          "/oauth2/**",
                           "/email/verify"
                       ).permitAll()
                       .anyRequest().authenticated())
+              .oauth2Login(oauth2 -> oauth2
+                  .successHandler(oAuth2LoginSuccessHandler())
+              )
               .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
               // 폼 로그인은 현재 사용하지 않음         
 //            .formLogin(formLogin -> formLogin
@@ -59,6 +66,12 @@ public class SecurityConfig {
   @Bean
   public JwtAuthenticationFilter jwtAuthenticationFilter(UserService userService) {
       return new JwtAuthenticationFilter(jwtUtil, userService);
+  }
+  
+ //oAuth2 설정
+  @Bean
+  public OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler() {
+      return new OAuth2LoginSuccessHandler(jwtUtil, userRepository);
   }
   
 }

--- a/back/src/main/java/org/kosa/tripTalk/email/Email.java
+++ b/back/src/main/java/org/kosa/tripTalk/email/Email.java
@@ -1,0 +1,36 @@
+package org.kosa.tripTalk.email;
+
+import java.time.LocalDateTime;
+
+import org.kosa.tripTalk.user.User;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "email_tokens")
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Email {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "email_tokens_seq_gen")
+    @SequenceGenerator(name = "email_tokens_seq_gen", sequenceName = "email_tokens_seq", allocationSize = 1)
+    private Long id;
+
+    private String token; // 토큰(UUID)
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user; // 유저정보
+
+    private LocalDateTime expiryDate; // 이메일 인증 토큰 만료일
+
+    private boolean confirmed; // 이메일 인증 완료 여부
+    
+    
+    
+}

--- a/back/src/main/java/org/kosa/tripTalk/email/EmailController.java
+++ b/back/src/main/java/org/kosa/tripTalk/email/EmailController.java
@@ -1,0 +1,22 @@
+package org.kosa.tripTalk.email;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/email/")
+public class EmailController {
+  
+  private final EmailService emailService;
+  
+  @GetMapping("verify")
+  public String verifyEmail(@RequestParam("token") String token) {
+    return emailService.verifyToken(token);
+  }
+  
+
+}

--- a/back/src/main/java/org/kosa/tripTalk/email/EmailRepository.java
+++ b/back/src/main/java/org/kosa/tripTalk/email/EmailRepository.java
@@ -1,0 +1,14 @@
+package org.kosa.tripTalk.email;
+
+import java.util.Optional;
+import org.kosa.tripTalk.user.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface EmailRepository extends JpaRepository<Email, Long> {
+
+  Optional<Email> findByToken(String token);
+  Optional<Email> findByUser(User user); //비밀번호 찾기용
+
+}

--- a/back/src/main/java/org/kosa/tripTalk/email/EmailService.java
+++ b/back/src/main/java/org/kosa/tripTalk/email/EmailService.java
@@ -1,0 +1,65 @@
+package org.kosa.tripTalk.email;
+
+import java.time.LocalDateTime;
+import org.kosa.tripTalk.user.User;
+import org.kosa.tripTalk.user.UserRepository;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class EmailService {
+  
+    @Value("${app.email.verify-url-base}")
+    private String verifyUrlBase;
+  
+    private final JavaMailSender mailSender;
+    private final EmailRepository emailRepository;
+    private final UserRepository repository;
+
+    //이메일 인증 요청
+    public void sendVerificationEmail(User user, String token) {
+      String verificationUrl = verifyUrlBase + token;
+      String subject = "이메일 인증을 완료해주세요.";
+      String text = "아래 링크를 클릭하여 이메일 인증을 완료해주세요:\n" + verificationUrl;
+      sendEmail(user.getEmail(), subject, text);
+  }
+    
+    //요청 내용
+    public void sendEmail(String to, String subject, String text) {
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setFrom("naong0711@gmail.com"); // Gmail 주소
+        message.setTo(to);
+        message.setSubject(subject);
+        message.setText(text);
+
+        mailSender.send(message);
+    }
+    
+    //이메일 인증 확인
+    public String verifyToken(String token) {
+      Email emailToken = emailRepository.findByToken(token)
+          .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 토큰입니다."));
+
+      if (emailToken.isConfirmed()) {
+          return "이미 인증된 계정입니다.";
+      }
+
+      if (emailToken.getExpiryDate().isBefore(LocalDateTime.now())) {
+          return "토큰이 만료되었습니다.";
+      }
+
+      emailToken.setConfirmed(true);
+      emailRepository.save(emailToken);
+      
+      //이메일 인증 완료 > 로그인 가능 처리
+      User user = emailToken.getUser();
+      user.setEmailVerified(true);
+      repository.save(user);
+
+      return "이메일 인증이 완료되었습니다.";
+  }
+}

--- a/back/src/main/java/org/kosa/tripTalk/jwt/JwtAuthenticationFilter.java
+++ b/back/src/main/java/org/kosa/tripTalk/jwt/JwtAuthenticationFilter.java
@@ -8,21 +8,20 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
 
+@Component
+@RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
   private final JwtUtil jwtUtil;
   private final UserService userService;
-
-  public JwtAuthenticationFilter(JwtUtil jwtUtil, UserService userService) {
-      this.jwtUtil = jwtUtil;
-      this.userService = userService;
-  }
 
   @Override
   protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)

--- a/back/src/main/java/org/kosa/tripTalk/user/User.java
+++ b/back/src/main/java/org/kosa/tripTalk/user/User.java
@@ -45,6 +45,9 @@ public class User {
     @Column(unique = true)
     private String socialId;
     
+    @Column(name = "email_verified")
+    private boolean emailVerified;
+    
     
     
     public enum Role {

--- a/back/src/main/java/org/kosa/tripTalk/user/UserController.java
+++ b/back/src/main/java/org/kosa/tripTalk/user/UserController.java
@@ -1,6 +1,8 @@
 package org.kosa.tripTalk.user;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -16,19 +18,33 @@ public class UserController {
   private final UserService userService;
   
   @PostMapping("login")
-  public ResponseEntity<LoginResponse> login(@RequestBody @Valid LoginRequest request) {
+  public ResponseEntity<?> login(@RequestBody @Valid LoginRequest request) {
     
     LoginResponse response = userService.login(request);
     
     return ResponseEntity.ok(response);
   }
   
+  
   @PostMapping("register")
-  public ResponseEntity<UserResponse> register(@RequestBody @Valid UserRequest request) {
+  public ResponseEntity<?> register(@RequestBody @Valid UserRequest request) {
     
     UserResponse response = userService.register(request);
     
     return ResponseEntity.ok(response);
   }
+  
+  @DeleteMapping("logout")
+  public ResponseEntity<?> logout() {
+    //추후 js에서 토큰 삭제
+//    function logout() {
+//      localStorage.removeItem("accessToken");
+//      localStorage.removeItem("refreshToken");
+//      location.href = "/login";
+//    }
+    return ResponseEntity.ok("로그아웃 완료");
+  }
+  
+  
 
 }

--- a/back/src/main/java/org/kosa/tripTalk/user/UserController.java
+++ b/back/src/main/java/org/kosa/tripTalk/user/UserController.java
@@ -22,5 +22,13 @@ public class UserController {
     
     return ResponseEntity.ok(response);
   }
+  
+  @PostMapping("register")
+  public ResponseEntity<UserResponse> register(@RequestBody @Valid UserRequest request) {
+    
+    UserResponse response = userService.register(request);
+    
+    return ResponseEntity.ok(response);
+  }
 
 }

--- a/back/src/main/java/org/kosa/tripTalk/user/UserRepository.java
+++ b/back/src/main/java/org/kosa/tripTalk/user/UserRepository.java
@@ -9,5 +9,10 @@ public interface UserRepository extends JpaRepository<User, Long>{
   
   //id로 유저 존재하는지 확인
   Optional<User> findByUserId(String userId);
+  
+  //존재여부검사
+  boolean existsByUserId(String userId);
+  boolean existsByEmail(String email);
+  boolean existsByNickname(String nickname);
 
 }

--- a/back/src/main/java/org/kosa/tripTalk/user/UserRepository.java
+++ b/back/src/main/java/org/kosa/tripTalk/user/UserRepository.java
@@ -9,6 +9,9 @@ public interface UserRepository extends JpaRepository<User, Long>{
   
   //id로 유저 존재하는지 확인
   Optional<User> findByUserId(String userId);
+
+  //소셜로그인 시 유저 찾기
+  Optional<User> findBySocialId(String socialId);
   
   //존재여부검사
   boolean existsByUserId(String userId);

--- a/back/src/main/java/org/kosa/tripTalk/user/UserRequest.java
+++ b/back/src/main/java/org/kosa/tripTalk/user/UserRequest.java
@@ -1,0 +1,39 @@
+package org.kosa.tripTalk.user;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserRequest {
+
+    @NotBlank
+    private String userId;
+
+    @Email
+    @NotBlank
+    private String email;
+
+    @NotBlank
+    private String name;
+
+    @NotBlank
+    private String password;
+
+    @NotBlank
+    private String nickname;
+
+    @NotBlank
+    @Pattern(
+        regexp = "^01[016789]-\\d{3,4}-\\d{4}$",
+        message = "전화번호 형식이 올바르지 않습니다. 예: 010-1234-5678"
+    )
+    private String phone;
+}

--- a/back/src/main/java/org/kosa/tripTalk/user/UserResponse.java
+++ b/back/src/main/java/org/kosa/tripTalk/user/UserResponse.java
@@ -1,0 +1,35 @@
+package org.kosa.tripTalk.user;
+
+import lombok.Getter;
+
+@Getter
+public class UserResponse {
+  
+  private String userId;
+  private String name;
+  private String email;
+  private String nickname;
+  private String phone;
+  private String role;
+  
+  public UserResponse(String userId, String email, String name, String nickname, String phone, String role){
+      this.userId = userId;
+      this.name = name;
+      this.email = email;
+      this.nickname = nickname;
+      this.phone = phone;
+      this.role = role;
+  }
+
+  public static UserResponse fromEntity(User user) {
+      return new UserResponse(
+          user.getUserId(),
+          user.getEmail(),
+          user.getName(),
+          user.getNickname(),
+          user.getPhone(),
+          user.getRole().name()
+      );
+  }
+
+}

--- a/back/src/main/java/org/kosa/tripTalk/user/UserService.java
+++ b/back/src/main/java/org/kosa/tripTalk/user/UserService.java
@@ -1,6 +1,11 @@
 package org.kosa.tripTalk.user;
 
+import java.time.LocalDateTime;
 import java.util.Date;
+import java.util.UUID;
+import org.kosa.tripTalk.email.Email;
+import org.kosa.tripTalk.email.EmailRepository;
+import org.kosa.tripTalk.email.EmailService;
 import org.kosa.tripTalk.jwt.JwtUtil;
 import org.kosa.tripTalk.jwt.RefreshToken;
 import org.kosa.tripTalk.jwt.RefreshTokenRepository;
@@ -18,8 +23,9 @@ public class UserService {
   private final UserRepository repository;
   private final RefreshTokenRepository tokenRepository;
   private final JwtUtil jwtUtil;
-  //회원가입 시 패스워드 암호화 - 미구현
   private final PasswordEncoder passwordEncoder;
+  private final EmailService emailService;
+  private final EmailRepository emailRepository;
 
   //로그인 요청
   public LoginResponse login(@Valid LoginRequest request) {
@@ -31,6 +37,11 @@ public class UserService {
     //입력된 비밀번호와 유저 비밀번호 비교 (암호화x)
     if (!passwordEncoder.matches(request.getPassword(), user.getPassword())) {
       throw new BadCredentialsException("비밀번호 틀림");
+  }
+    
+    //이메일 미인증 시
+    if (!user.isEmailVerified()) {
+      throw new IllegalStateException("이메일 인증 후 로그인할 수 있습니다. 이메일을 확인해 주세요.");
   }
     //토큰 생성
     String accessToken  = jwtUtil.generateAccessToken(user.getUserId(), user.getRole());
@@ -55,9 +66,37 @@ public class UserService {
     return user;
   }
   
+  //회원가입-아이디 중복 확인
+  public void checkUserId(String userId) {
+    if(repository.existsByUserId(userId)) {
+      throw new IllegalArgumentException("이미 사용 중인 아이디입니다.");
+    }
+  }
+  
+  //회원가입-이메일 중복 확인
+  public void checkEmail(String email) {
+    if(repository.existsByEmail(email)) {
+      throw new IllegalArgumentException("이미 가입된 이메일입니다.");
+    }
+  }
+  
+  //회원가입-닉네임 중복 확인
+  public void checkNickname(String nickname) {
+    if(repository.existsByNickname(nickname)) {
+      throw new IllegalArgumentException("이미 사용 중인 닉네임입니다.");
+    }
+  }
+  
   //회원가입
   public UserResponse register(UserRequest request) {
     
+    //중복검사
+    checkUserId(request.getUserId());
+    checkEmail(request.getEmail());
+    checkNickname(request.getNickname());
+    
+    
+    //비밀번호 암호화
     String encodedPassword = passwordEncoder.encode(request.getPassword());
     
     User user = User.builder()
@@ -68,9 +107,26 @@ public class UserService {
         .phone(request.getPhone())
         .password(encodedPassword) 
         .role(User.Role.USER)
+        .emailVerified(false)
         .build();
 
     User savedUser = repository.save(user);
+    
+    //이메일 인증 토큰 생성
+    String token = UUID.randomUUID().toString();
+    Email emailToken = Email.builder()
+        .token(token)
+        .user(savedUser)
+        .expiryDate(LocalDateTime.now().plusHours(24))
+        .confirmed(false)
+        .build();
+    emailRepository.save(emailToken);
+
+    //이메일 발송
+    String subject = "이메일 인증을 완료해주세요.";
+    String verificationUrl = "http://localhost:8080/email/verify?token=" + token;
+    String text = "아래 링크를 클릭하여 이메일 인증을 완료해주세요:\n" + verificationUrl;
+    emailService.sendEmail(savedUser.getEmail(), subject, text);
 
     return UserResponse.fromEntity(savedUser);
 }

--- a/back/src/main/java/org/kosa/tripTalk/user/UserService.java
+++ b/back/src/main/java/org/kosa/tripTalk/user/UserService.java
@@ -29,10 +29,9 @@ public class UserService {
         .orElseThrow(() -> new UsernameNotFoundException("사용자 없음"));
     
     //입력된 비밀번호와 유저 비밀번호 비교 (암호화x)
-    if (!user.getPassword().equals(request.getPassword())) {
+    if (!passwordEncoder.matches(request.getPassword(), user.getPassword())) {
       throw new BadCredentialsException("비밀번호 틀림");
-    }
-    
+  }
     //토큰 생성
     String accessToken  = jwtUtil.generateAccessToken(user.getUserId(), user.getRole());
     String refreshToken = jwtUtil.generateRefreshToken(user.getUserId());

--- a/back/src/main/java/org/kosa/tripTalk/user/UserService.java
+++ b/back/src/main/java/org/kosa/tripTalk/user/UserService.java
@@ -19,14 +19,11 @@ public class UserService {
   private final RefreshTokenRepository tokenRepository;
   private final JwtUtil jwtUtil;
   //회원가입 시 패스워드 암호화 - 미구현
-  private PasswordEncoder passwordEncoder;
+  private final PasswordEncoder passwordEncoder;
 
+  //로그인 요청
   public LoginResponse login(@Valid LoginRequest request) {
-    
-    //인증 시도
-    System.out.println(request.getUserId());
-    System.out.println(request.getPassword());
-    
+  
     //유저 정보 가져오기
     User user =  repository.findByUserId(request.getUserId())
         .orElseThrow(() -> new UsernameNotFoundException("사용자 없음"));
@@ -50,7 +47,7 @@ public class UserService {
     return new LoginResponse(accessToken, user.getName(), user.getRole());
   }
 
-  //유저 아이디로 유저 정보 가져오기
+  //유저 아이디로 유저 정보 가져오기(jwt 요청용)
   public User loadUserByUserId(String userId) {
     
     User user =  repository.findByUserId(userId)
@@ -58,5 +55,25 @@ public class UserService {
     
     return user;
   }
+  
+  //회원가입
+  public UserResponse register(UserRequest request) {
+    
+    String encodedPassword = passwordEncoder.encode(request.getPassword());
+    
+    User user = User.builder()
+        .userId(request.getUserId())
+        .name(request.getName())
+        .email(request.getEmail())
+        .nickname(request.getNickname())
+        .phone(request.getPhone())
+        .password(encodedPassword) 
+        .role(User.Role.USER)
+        .build();
+
+    User savedUser = repository.save(user);
+
+    return UserResponse.fromEntity(savedUser);
+}
 
 }

--- a/back/src/main/resources/application.properties
+++ b/back/src/main/resources/application.properties
@@ -15,3 +15,13 @@ spring.jpa.hibernate.naming.physical-strategy=org.hibernate.boot.model.naming.Ph
 
 ##jwt SECRET_KEY
 jwt.secret-key=zCZSwys5xNyWlfwR7nP51kYvfviH6kIN
+
+##Gmail STMP
+spring.mail.host=smtp.gmail.com
+spring.mail.port=587
+spring.mail.username=naong0711@gmail.com
+spring.mail.password=xexv irip eiue jzrm
+spring.mail.properties.mail.smtp.auth=true
+spring.mail.properties.mail.smtp.starttls.enable=true
+
+app.email.verify-url-base=http://localhost:8080/email/verify?token=

--- a/back/src/main/resources/application.properties
+++ b/back/src/main/resources/application.properties
@@ -24,4 +24,17 @@ spring.mail.password=xexv irip eiue jzrm
 spring.mail.properties.mail.smtp.auth=true
 spring.mail.properties.mail.smtp.starttls.enable=true
 
+##이메일 인증
 app.email.verify-url-base=http://localhost:8080/email/verify?token=
+
+# Kakao OAuth2 설정
+spring.security.oauth2.client.registration.kakao.client-id=69defb2d16d643055c6d13227979a378
+spring.security.oauth2.client.registration.kakao.redirect-uri={baseUrl}/api/user/login/kakao/code
+spring.security.oauth2.client.registration.kakao.authorization-grant-type=authorization_code
+spring.security.oauth2.client.registration.kakao.client-name=Kakao
+spring.security.oauth2.client.registration.kakao.scope=profile_nickname
+
+spring.security.oauth2.client.provider.kakao.authorization-uri=https://kauth.kakao.com/oauth/authorize
+spring.security.oauth2.client.provider.kakao.token-uri=https://kauth.kakao.com/oauth/token
+spring.security.oauth2.client.provider.kakao.user-info-uri=https://kapi.kakao.com/v2/user/me
+spring.security.oauth2.client.provider.kakao.user-name-attribute=id


### PR DESCRIPTION
🔧 작업 내용
- 소셜 로그인(카카오) 기능 구현 > onAuthenticationSuccess()에서 사용자 저장 로직 구현 (테스트 미진행)
- Postman으로 Kakao 고유 ID 및 액세스 토큰 테스트 완료
- 회원가입 시 이메일 인증 기능 추가 : Gmail STMP 이용
- PasswordEncoder 패스워드 암호화
- JwtAuthenticationFilter, SecurityConfig 간 순환 구조 문제 해결

📌 참고 사항
- 카카오 로그인 연동은 현재 Postman을 통해 테스트하였으며, 프론트엔드 연동 이후 실제 사용자 저장 및 인증 흐름 검증 필요