### PR TITLE
Feat/product v2

### DIFF
--- a/back/.gitignore
+++ b/back/.gitignore
@@ -5,6 +5,9 @@ build/
 !**/src/main/**/build/
 !**/src/test/**/build/
 
+# QueryDSL generated files (exclude from git)
+src/main/generated/
+
 ### STS ###
 .apt_generated
 .classpath

--- a/back/build.gradle
+++ b/back/build.gradle
@@ -31,6 +31,10 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'com.h2database:h2'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'io.github.openfeign.querydsl:querydsl-jpa:6.10.1'
+	annotationProcessor 'io.github.openfeign.querydsl:querydsl-apt:6.10.1:jpa'
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.oracle.database.jdbc:ojdbc11'
@@ -49,6 +53,42 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
+}
+
+// QueryDsl 디렉토리 경로
+def querydslSrcDir = 'src/main/generated/querydsl'
+
+// Q파일 생성 디렉토리 삭제 (clean 시)
+clean {
+    delete file(querydslSrcDir)
+}
+
+// Q파일 생성 디렉토리 지정
+tasks.withType(JavaCompile).configureEach {
+    options.generatedSourceOutputDirectory = file(querydslSrcDir)
+}
+
+// QueryDSL 전용 소스셋 등록
+sourceSets {
+    main {
+        java {
+            srcDirs += querydslSrcDir
+        }
+    }
+}
+
+// QueryDSL 전용 태스크 (Q타입만 생성용)
+tasks.register('generateQueryDSL', JavaCompile) {
+    group = 'build'
+    description = 'Generate Q classes using QueryDSL'
+
+    source = fileTree('src/main/java') {
+        include 'org/kosa/tripTalk/*/**/*.java'
+    }
+
+    classpath = sourceSets.main.compileClasspath
+    destinationDirectory = file(querydslSrcDir)
+    options.annotationProcessorPath = configurations.annotationProcessor
 }
 
 tasks.named('test') {

--- a/back/src/main/java/org/kosa/tripTalk/common/dto/PageRequestDTO.java
+++ b/back/src/main/java/org/kosa/tripTalk/common/dto/PageRequestDTO.java
@@ -18,6 +18,9 @@ public class PageRequestDTO {
 	private String sort = "id,desc";
 	
 	public Pageable toPageable() {
+		if(sort == null || sort.isBlank())
+			return PageRequest.of(page -1, size);
+		
 		String [] sortParams = sort.split(",");
 		String sortFiled = sortParams[0];
 		

--- a/back/src/main/java/org/kosa/tripTalk/common/dto/PageRequestDTO.java
+++ b/back/src/main/java/org/kosa/tripTalk/common/dto/PageRequestDTO.java
@@ -1,0 +1,30 @@
+package org.kosa.tripTalk.common.dto;
+
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PageRequestDTO {
+	
+	private int page = 1;
+	private int size = 10;
+	private String sort = "id,desc";
+	
+	public Pageable toPageable() {
+		String [] sortParams = sort.split(",");
+		String sortFiled = sortParams[0];
+		
+		Sort.Direction direction = sortParams.length > 1
+							? Sort.Direction.fromString(sortParams[1])
+							: Sort.Direction.DESC;
+		
+		return PageRequest.of(page -1, size, Sort.by(direction, sortFiled));
+	}
+}

--- a/back/src/main/java/org/kosa/tripTalk/common/dto/Search.java
+++ b/back/src/main/java/org/kosa/tripTalk/common/dto/Search.java
@@ -1,0 +1,16 @@
+package org.kosa.tripTalk.common.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class Search {
+	private String searchKey;
+	private String searchValue;
+	
+	public boolean isValid() {
+		return searchKey != null && !searchKey.isBlank()
+				&& searchValue != null && !searchValue.isBlank();
+	}
+}

--- a/back/src/main/java/org/kosa/tripTalk/common/predicate/PredicateBuilder.java
+++ b/back/src/main/java/org/kosa/tripTalk/common/predicate/PredicateBuilder.java
@@ -1,0 +1,11 @@
+package org.kosa.tripTalk.common.predicate;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.StringPath;
+
+public class PredicateBuilder {
+	
+	public static BooleanExpression applyKeyword(StringPath field, String keyword) {
+		return field.containsIgnoreCase(keyword);
+	}
+}

--- a/back/src/main/java/org/kosa/tripTalk/common/querydsl/QuerydslConfig.java
+++ b/back/src/main/java/org/kosa/tripTalk/common/querydsl/QuerydslConfig.java
@@ -1,0 +1,21 @@
+package org.kosa.tripTalk.common.querydsl;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+
+@Configuration
+public class QuerydslConfig {
+	
+	@PersistenceContext
+	private EntityManager em;
+	
+	@Bean
+	public JPAQueryFactory jpaQueryFactory() {
+		return new JPAQueryFactory(em);
+	}
+}

--- a/back/src/main/java/org/kosa/tripTalk/common/querydsl/QuerydslUtils.java
+++ b/back/src/main/java/org/kosa/tripTalk/common/querydsl/QuerydslUtils.java
@@ -1,0 +1,20 @@
+package org.kosa.tripTalk.common.querydsl;
+
+import org.springframework.data.domain.Sort;
+
+import com.querydsl.core.types.EntityPath;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.PathBuilder;
+
+public class QuerydslUtils {
+	public static OrderSpecifier<?>[] toOrders(Sort sort, EntityPath<?> root) {
+		return sort.stream()
+				.map(order -> {
+					PathBuilder pathBuilder = new PathBuilder<>(root.getType(), root.getMetadata());
+					return order.isAscending()
+							? pathBuilder.getString(order.getProperty()).asc()
+							: pathBuilder.getString(order.getProperty()).desc();
+				})
+				.toArray(OrderSpecifier[]::new);
+	}
+}

--- a/back/src/main/java/org/kosa/tripTalk/product/Product.java
+++ b/back/src/main/java/org/kosa/tripTalk/product/Product.java
@@ -49,19 +49,19 @@ public class Product {
 
 	@Column(nullable = false)
 	private String address;
-	
+
 	@Column(nullable = false)
-    private LocalDateTime startDate;
-	
+	private LocalDateTime startDate;
+
 	@Column(nullable = false)
-    private LocalDateTime endDate;
-	
+	private LocalDateTime endDate;
+
 	public void updateFromDTO(ProductRequestDTO dto) {
-	    this.title = dto.getTitle();
-	    this.description = dto.getDescription();
-	    this.address = dto.getAddress();
-	    this.price = dto.getPrice();
-	    this.startDate = dto.getStartDate();
-	    this.endDate = dto.getEndDate();
+		this.title = dto.getTitle();
+		this.description = dto.getDescription();
+		this.address = dto.getAddress();
+		this.price = dto.getPrice();
+		this.startDate = dto.getStartDate();
+		this.endDate = dto.getEndDate();
 	}
 }

--- a/back/src/main/java/org/kosa/tripTalk/product/Product.java
+++ b/back/src/main/java/org/kosa/tripTalk/product/Product.java
@@ -56,5 +56,12 @@ public class Product {
 	@Column(nullable = false)
     private LocalDateTime endDate;
 	
-	
+	public void updateFromDTO(ProductRequestDTO dto) {
+	    this.title = dto.getTitle();
+	    this.description = dto.getDescription();
+	    this.address = dto.getAddress();
+	    this.price = dto.getPrice();
+	    this.startDate = dto.getStartDate();
+	    this.endDate = dto.getEndDate();
+	}
 }

--- a/back/src/main/java/org/kosa/tripTalk/product/ProductController.java
+++ b/back/src/main/java/org/kosa/tripTalk/product/ProductController.java
@@ -1,8 +1,7 @@
 package org.kosa.tripTalk.product;
 
-import java.util.List;
-
 import org.kosa.tripTalk.common.dto.PageRequestDTO;
+import org.kosa.tripTalk.common.dto.Search;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
@@ -47,9 +46,12 @@ public class ProductController {
 	}
 	
 	@GetMapping
-    public ResponseEntity<Page<ProductResponseDTO>> getAllProducts(PageRequestDTO pageRequestDTO) {
+    public ResponseEntity<Page<ProductResponseDTO>> getAllProducts(
+    		PageRequestDTO pageRequestDTO,
+    		Search search
+    		) {
 		Pageable pageable = pageRequestDTO.toPageable();
-		Page<ProductResponseDTO> result = productService.getAllProducts(pageable);
+		Page<ProductResponseDTO> result = productService.getAllProducts(pageable, search);
 		
         return ResponseEntity.ok(result);
     }

--- a/back/src/main/java/org/kosa/tripTalk/product/ProductController.java
+++ b/back/src/main/java/org/kosa/tripTalk/product/ProductController.java
@@ -1,5 +1,7 @@
 package org.kosa.tripTalk.product;
 
+import java.util.List;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -40,4 +42,10 @@ public class ProductController {
 		
 		return ResponseEntity.ok(ProductResponseDTO.from(updateProduct));
 	}
+	
+	@GetMapping
+    public ResponseEntity<List<ProductResponseDTO>> getAllProducts() {
+        List<ProductResponseDTO> result = productService.getAllProducts();
+        return ResponseEntity.ok(result);
+    }
 }

--- a/back/src/main/java/org/kosa/tripTalk/product/ProductController.java
+++ b/back/src/main/java/org/kosa/tripTalk/product/ProductController.java
@@ -2,6 +2,9 @@ package org.kosa.tripTalk.product;
 
 import java.util.List;
 
+import org.kosa.tripTalk.common.dto.PageRequestDTO;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -44,8 +47,10 @@ public class ProductController {
 	}
 	
 	@GetMapping
-    public ResponseEntity<List<ProductResponseDTO>> getAllProducts() {
-        List<ProductResponseDTO> result = productService.getAllProducts();
+    public ResponseEntity<Page<ProductResponseDTO>> getAllProducts(PageRequestDTO pageRequestDTO) {
+		Pageable pageable = pageRequestDTO.toPageable();
+		Page<ProductResponseDTO> result = productService.getAllProducts(pageable);
+		
         return ResponseEntity.ok(result);
     }
 }

--- a/back/src/main/java/org/kosa/tripTalk/product/ProductController.java
+++ b/back/src/main/java/org/kosa/tripTalk/product/ProductController.java
@@ -5,6 +5,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -29,5 +30,14 @@ public class ProductController {
 		ProductResponseDTO response = productService.getProductById(id);
 		return ResponseEntity.ok(response);
 		
+	}
+	
+	@PutMapping("/{id}")
+	public ResponseEntity<ProductResponseDTO> updateProduct(
+			@PathVariable Long id,
+			@RequestBody ProductRequestDTO requestDTO) {
+		Product updateProduct = productService.update(id, requestDTO);
+		
+		return ResponseEntity.ok(ProductResponseDTO.from(updateProduct));
 	}
 }

--- a/back/src/main/java/org/kosa/tripTalk/product/ProductPredicateBuilder.java
+++ b/back/src/main/java/org/kosa/tripTalk/product/ProductPredicateBuilder.java
@@ -1,0 +1,25 @@
+package org.kosa.tripTalk.product;
+
+import org.kosa.tripTalk.common.dto.Search;
+import org.kosa.tripTalk.common.predicate.PredicateBuilder;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+
+public class ProductPredicateBuilder {
+	
+	public static BooleanExpression build(QProduct product, Search search) {
+		if (search == null || !search.isValid())
+			return null;
+		
+		String key = search.getSearchKey();
+		String value = search.getSearchValue();
+		
+		return switch (key) {
+				case "title" -> PredicateBuilder.applyKeyword(product.title, value);
+				case "description" -> PredicateBuilder.applyKeyword(product.description, value);
+				case "address" -> PredicateBuilder.applyKeyword(product.address, value);
+				default -> null;
+		};
+	}
+
+}

--- a/back/src/main/java/org/kosa/tripTalk/product/ProductRepository.java
+++ b/back/src/main/java/org/kosa/tripTalk/product/ProductRepository.java
@@ -4,6 +4,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface ProductRepository extends JpaRepository<Product, Long> {
+public interface ProductRepository extends JpaRepository<Product, Long>, ProductRepositoryCustom {
 
 }

--- a/back/src/main/java/org/kosa/tripTalk/product/ProductRepositoryCustom.java
+++ b/back/src/main/java/org/kosa/tripTalk/product/ProductRepositoryCustom.java
@@ -1,0 +1,9 @@
+package org.kosa.tripTalk.product;
+
+import org.kosa.tripTalk.common.dto.Search;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface ProductRepositoryCustom {
+	Page<ProductResponseDTO> searchAll(Pageable pageable, Search search);
+}

--- a/back/src/main/java/org/kosa/tripTalk/product/ProductRepositoryImpl.java
+++ b/back/src/main/java/org/kosa/tripTalk/product/ProductRepositoryImpl.java
@@ -1,0 +1,49 @@
+package org.kosa.tripTalk.product;
+
+import java.util.List;
+
+import org.kosa.tripTalk.common.dto.Search;
+import org.kosa.tripTalk.common.querydsl.QuerydslUtils;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class ProductRepositoryImpl implements ProductRepositoryCustom {
+	
+	private final JPAQueryFactory queryFactory;
+
+	@Override
+	public Page<ProductResponseDTO> searchAll(Pageable pageable, Search search) {
+		QProduct product = QProduct.product;
+		
+		BooleanExpression condition = ProductPredicateBuilder.build(product, search);
+		
+		List<Product> contents = queryFactory
+							.selectFrom(product)
+							.where(condition)
+							.offset(pageable.getOffset())
+							.limit(pageable.getPageSize())
+							.orderBy(QuerydslUtils.toOrders(pageable.getSort(), product))
+							.fetch();
+		
+		Long total = queryFactory
+							.select(product.count())
+							.from(product)
+							.where(condition)
+							.fetchOne();
+		
+		List<ProductResponseDTO> dtoList = contents.stream()
+						.map(ProductResponseDTO::from)
+						.toList();
+		
+		return new PageImpl<>(dtoList, pageable, total);
+	}
+}

--- a/back/src/main/java/org/kosa/tripTalk/product/ProductRequestDTO.java
+++ b/back/src/main/java/org/kosa/tripTalk/product/ProductRequestDTO.java
@@ -2,6 +2,9 @@ package org.kosa.tripTalk.product;
 
 import java.time.LocalDateTime;
 
+import org.kosa.tripTalk.category.Category;
+import org.kosa.tripTalk.seller.Seller;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -20,4 +23,17 @@ public class ProductRequestDTO {
     private LocalDateTime endDate;
     private Long sellerId;
     private Long categoryId;
+    
+    public Product toEntity(Seller seller, Category category) {
+        return Product.builder()
+                .title(this.title)
+                .description(this.description)
+                .address(this.address)
+                .price(this.price)
+                .startDate(this.startDate)
+                .endDate(this.endDate)
+                .seller(seller)
+                .category(category)
+                .build();
+    }
 }

--- a/back/src/main/java/org/kosa/tripTalk/product/ProductService.java
+++ b/back/src/main/java/org/kosa/tripTalk/product/ProductService.java
@@ -54,4 +54,13 @@ public class ProductService {
 			.orElseThrow(() -> new IllegalArgumentException("해당 상품이 존재하지 않습니다."));
 		return ProductResponseDTO.from(product);
 	}
+
+	public Product update(Long id, ProductRequestDTO dto) {
+		Product product = productRepository.findById(id)
+		        .orElseThrow(() -> new IllegalArgumentException("해당 상품이 존재하지 않습니다."));
+		
+		product.updateFromDTO(dto);
+	    
+		return product;
+	}
 }

--- a/back/src/main/java/org/kosa/tripTalk/product/ProductService.java
+++ b/back/src/main/java/org/kosa/tripTalk/product/ProductService.java
@@ -9,6 +9,8 @@ import org.kosa.tripTalk.seller.Seller;
 import org.kosa.tripTalk.seller.SellerRepository;
 import org.kosa.tripTalk.user.User;
 import org.kosa.tripTalk.user.UserRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -58,10 +60,9 @@ public class ProductService {
 		return product;
 	}
 
-	public List<ProductResponseDTO> getAllProducts() {
-		return productRepository.findAll().stream()
-						.map(ProductResponseDTO::from)
-						.collect(Collectors.toList());
+	public Page<ProductResponseDTO> getAllProducts(Pageable pageable) {
+		return productRepository.findAll(pageable)
+						.map(ProductResponseDTO::from);
 	}
 	
 }

--- a/back/src/main/java/org/kosa/tripTalk/product/ProductService.java
+++ b/back/src/main/java/org/kosa/tripTalk/product/ProductService.java
@@ -1,5 +1,8 @@
 package org.kosa.tripTalk.product;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 import org.kosa.tripTalk.category.Category;
 import org.kosa.tripTalk.category.CategoryRepository;
 import org.kosa.tripTalk.seller.Seller;
@@ -63,4 +66,30 @@ public class ProductService {
 	    
 		return product;
 	}
+
+	public List<ProductResponseDTO> getAllProducts() {
+		return productRepository.findAll().stream()
+						.map(ProductResponseDTO::from)
+						.collect(Collectors.toList());
+	}
+	
 }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/back/src/main/java/org/kosa/tripTalk/product/ProductService.java
+++ b/back/src/main/java/org/kosa/tripTalk/product/ProductService.java
@@ -38,16 +38,7 @@ public class ProductService {
                 .orElseThrow(() -> new IllegalArgumentException("카테고리가 존재하지 않습니다."));
         
      // 4. 상품 생성 및 저장
-        Product product = Product.builder()
-                .title(request.getTitle())
-                .description(request.getDescription())
-                .address(request.getAddress())
-                .price(request.getPrice())
-                .startDate(request.getStartDate())
-                .endDate(request.getEndDate())
-                .seller(seller)
-                .category(category)
-                .build();
+        Product product = request.toEntity(seller, category);
         
         productRepository.save(product);
 	}

--- a/back/src/main/java/org/kosa/tripTalk/product/ProductService.java
+++ b/back/src/main/java/org/kosa/tripTalk/product/ProductService.java
@@ -5,6 +5,7 @@ import java.util.stream.Collectors;
 
 import org.kosa.tripTalk.category.Category;
 import org.kosa.tripTalk.category.CategoryRepository;
+import org.kosa.tripTalk.common.dto.Search;
 import org.kosa.tripTalk.seller.Seller;
 import org.kosa.tripTalk.seller.SellerRepository;
 import org.kosa.tripTalk.user.User;
@@ -60,9 +61,8 @@ public class ProductService {
 		return product;
 	}
 
-	public Page<ProductResponseDTO> getAllProducts(Pageable pageable) {
-		return productRepository.findAll(pageable)
-						.map(ProductResponseDTO::from);
+	public Page<ProductResponseDTO> getAllProducts(Pageable pageable, Search search) {
+		return productRepository.searchAll(pageable, search);
 	}
 	
 }

--- a/back/src/main/java/org/kosa/tripTalk/seller/Seller.java
+++ b/back/src/main/java/org/kosa/tripTalk/seller/Seller.java
@@ -27,12 +27,8 @@ public class Seller {
 	
 	@Id
 	private Long id;
-
-	@Id
-	private Long id;
 	
 	@OneToOne
-
 	@JoinColumn(name = "id")
 	@MapsId
 	private User user;

--- a/back/src/test/java/org/kosa/tripTalk/product/ProductServiceTest.java
+++ b/back/src/test/java/org/kosa/tripTalk/product/ProductServiceTest.java
@@ -159,4 +159,6 @@ class ProductServiceTest {
 	    assertThat(result).extracting("title")
 	        .containsExactlyInAnyOrder("제주도 여행", "부산 투어");
 	}
+	
+	
 }

--- a/back/src/test/java/org/kosa/tripTalk/product/ProductServiceTest.java
+++ b/back/src/test/java/org/kosa/tripTalk/product/ProductServiceTest.java
@@ -124,4 +124,39 @@ class ProductServiceTest {
 	    assertThat(updatedProduct.getAddress()).isEqualTo("부산 해운대");
 	    assertThat(updatedProduct.getPrice()).isEqualTo(200000);
 	}
+	
+	@Test
+	@DisplayName("상품 목록 조회")
+	void getAllProducts_success() {
+	    // given
+	    productRepository.save(Product.builder()
+	            .title("제주도 여행")
+	            .description("3박 4일 힐링")
+	            .address("제주")
+	            .price(300000)
+	            .startDate(LocalDateTime.now().plusDays(3))
+	            .endDate(LocalDateTime.now().plusDays(6))
+	            .category(savedCategory)
+	            .seller(savedSeller)
+	            .build());
+
+	    productRepository.save(Product.builder()
+	            .title("부산 투어")
+	            .description("2박 3일 먹방")
+	            .address("부산")
+	            .price(250000)
+	            .startDate(LocalDateTime.now().plusDays(2))
+	            .endDate(LocalDateTime.now().plusDays(4))
+	            .category(savedCategory)
+	            .seller(savedSeller)
+	            .build());
+
+	    // when
+	    List<ProductResponseDTO> result = productService.getAllProducts();
+
+	    // then
+	    assertThat(result).hasSize(2);
+	    assertThat(result).extracting("title")
+	        .containsExactlyInAnyOrder("제주도 여행", "부산 투어");
+	}
 }

--- a/back/src/test/java/org/kosa/tripTalk/product/ProductServiceTest.java
+++ b/back/src/test/java/org/kosa/tripTalk/product/ProductServiceTest.java
@@ -22,6 +22,7 @@ import org.springframework.transaction.annotation.Transactional;
 @DisplayName("상품 테스트")
 @SpringBootTest
 @Transactional
+@ActiveProfiles("test")
 class ProductServiceTest {
 
 	@Autowired
@@ -67,7 +68,7 @@ class ProductServiceTest {
     }
 	
 	@Test
-    @DisplayName("정상적인 상품 등록이 성공해야 한다")
+    @DisplayName("정상 상품 등록")
     void createProduct_success() {
         // given
         ProductRequestDTO request = ProductRequestDTO.builder()
@@ -90,4 +91,37 @@ class ProductServiceTest {
         assertThat(result.get(0).getTitle()).isEqualTo("제주도 여행");
     }
 
+	@Test
+	@DisplayName("상품 정상 수정")
+	void updateProduct_success() {
+	    // given
+	    Product savedProduct = productRepository.save(Product.builder()
+	            .title("기존 제목")
+	            .description("기존 설명")
+	            .address("서울시 강남구")
+	            .price(100000)
+	            .startDate(LocalDateTime.now().plusDays(5))
+	            .endDate(LocalDateTime.now().plusDays(7))
+	            .category(savedCategory)
+	            .seller(savedSeller)
+	            .build());
+
+	    ProductUpdateRequestDTO updateDto = ProductUpdateRequestDTO.builder()
+	            .title("수정된 제목")
+	            .description("수정된 설명")
+	            .address("부산 해운대")
+	            .price(200000)
+	            .startDate(LocalDateTime.now().plusDays(10))
+	            .endDate(LocalDateTime.now().plusDays(13))
+	            .build();
+
+	    // when
+	    productService.update(savedProduct.getId(), updateDto);
+
+	    // then
+	    Product updatedProduct = productRepository.findById(savedProduct.getId()).orElseThrow();
+	    assertThat(updatedProduct.getTitle()).isEqualTo("수정된 제목");
+	    assertThat(updatedProduct.getAddress()).isEqualTo("부산 해운대");
+	    assertThat(updatedProduct.getPrice()).isEqualTo(200000);
+	}
 }

--- a/back/src/test/java/org/kosa/tripTalk/product/ProductServiceTest.java
+++ b/back/src/test/java/org/kosa/tripTalk/product/ProductServiceTest.java
@@ -131,43 +131,8 @@ class ProductServiceTest {
 	}
 	
 	@Test
-	@DisplayName("상품 목록 조회")
-	void getAllProducts_success() {
-	    // given
-	    productRepository.save(Product.builder()
-	            .title("제주도 여행")
-	            .description("3박 4일 힐링")
-	            .address("제주")
-	            .price(300000)
-	            .startDate(LocalDateTime.now().plusDays(3))
-	            .endDate(LocalDateTime.now().plusDays(6))
-	            .category(savedCategory)
-	            .seller(savedSeller)
-	            .build());
-
-	    productRepository.save(Product.builder()
-	            .title("부산 투어")
-	            .description("2박 3일 먹방")
-	            .address("부산")
-	            .price(250000)
-	            .startDate(LocalDateTime.now().plusDays(2))
-	            .endDate(LocalDateTime.now().plusDays(4))
-	            .category(savedCategory)
-	            .seller(savedSeller)
-	            .build());
-
-	    // when
-	    List<ProductResponseDTO> result = productService.getAllProducts();
-
-	    // then
-	    assertThat(result).hasSize(2);
-	    assertThat(result).extracting("title")
-	        .containsExactlyInAnyOrder("제주도 여행", "부산 투어");
-	}
-	
-	@Test
-	@DisplayName("상품 목록 페이징 조회 성공")
-	void getAllProducts_withPaging_success() {
+	@DisplayName("상품 목록 페이징 + 정렬 조회 성공")
+	void getAllProducts_withPagingAndSorting_success() {
 	    // given: 15개의 상품 등록
 	    for (int i = 1; i <= 15; i++) {
 	        productRepository.save(Product.builder()
@@ -182,7 +147,7 @@ class ProductServiceTest {
 	                .build());
 	    }
 
-	    PageRequestDTO pageRequestDTO = new PageRequestDTO(1, 10, "");
+	    PageRequestDTO pageRequestDTO = new PageRequestDTO(1, 10, "price,asc");
 	    Pageable pageable = pageRequestDTO.toPageable();
 
 	    // when

--- a/back/src/test/java/org/kosa/tripTalk/product/ProductServiceTest.java
+++ b/back/src/test/java/org/kosa/tripTalk/product/ProductServiceTest.java
@@ -106,7 +106,7 @@ class ProductServiceTest {
 	            .seller(savedSeller)
 	            .build());
 
-	    ProductUpdateRequestDTO updateDto = ProductUpdateRequestDTO.builder()
+	    ProductRequestDTO updateDto = ProductRequestDTO.builder()
 	            .title("수정된 제목")
 	            .description("수정된 설명")
 	            .address("부산 해운대")

--- a/back/src/test/java/org/kosa/tripTalk/product/ProductServiceTest.java
+++ b/back/src/test/java/org/kosa/tripTalk/product/ProductServiceTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
 import org.kosa.tripTalk.category.Category;
 import org.kosa.tripTalk.category.CategoryRepository;
 import org.kosa.tripTalk.common.dto.PageRequestDTO;
+import org.kosa.tripTalk.common.dto.Search;
 import org.kosa.tripTalk.seller.Seller;
 import org.kosa.tripTalk.seller.SellerRepository;
 import org.kosa.tripTalk.user.User;
@@ -18,9 +19,7 @@ import org.kosa.tripTalk.user.UserRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -131,13 +130,13 @@ class ProductServiceTest {
 	}
 	
 	@Test
-	@DisplayName("상품 목록 페이징 + 정렬 조회 성공")
-	void getAllProducts_withPagingAndSorting_success() {
+	@DisplayName("상품 목록 페이징 + 정렬 + 검색 조회 성공")
+	void getAllProducts_withPagingSortingAndSearch_success() {
 	    // given: 15개의 상품 등록
 	    for (int i = 1; i <= 15; i++) {
 	        productRepository.save(Product.builder()
-	                .title("상품" + i)
-	                .description("설명" + i)
+	                .title("제주 상품 " + i)
+	                .description("힐링 설명 " + i)
 	                .address("주소" + i)
 	                .price(10000 * i)
 	                .startDate(LocalDateTime.now().plusDays(i))
@@ -150,15 +149,20 @@ class ProductServiceTest {
 	    PageRequestDTO pageRequestDTO = new PageRequestDTO(1, 10, "price,asc");
 	    Pageable pageable = pageRequestDTO.toPageable();
 
+	    // 검색 조건: title에 "제주" 포함
+		Search search = new Search();
+	    search.setSearchKey("title");
+	    search.setSearchValue("제주");
+
 	    // when
-	    Page<ProductResponseDTO> result = productService.getAllProducts(pageable);
+	    Page<ProductResponseDTO> result = productService.getAllProducts(pageable, search);
 
 	    // then
-	    assertThat(result.getContent()).hasSize(10);                 // 페이지 크기만큼 반환
-	    assertThat(result.getTotalElements()).isEqualTo(15);         // 전체 상품 수
+	    assertThat(result.getContent()).hasSize(10);                 // 1페이지에 10개
+	    assertThat(result.getTotalElements()).isEqualTo(15);         // 총 15개 중 모두 "제주" 포함
 	    assertThat(result.getTotalPages()).isEqualTo(2);             // 총 2페이지
 	    assertThat(result.isFirst()).isTrue();                       // 첫 페이지
 	    assertThat(result.isLast()).isFalse();                       // 아직 마지막 아님
-	    assertThat(result.getContent().get(0).getPrice()).isEqualTo(10000); // 정렬 확인
+	    assertThat(result.getContent().get(0).getPrice()).isEqualTo(10000); // 정렬 확인 (오름차순)
 	}
 }


### PR DESCRIPTION
## 🔧 작업 내용
- 상품 등록 시 `toEntity()` 메서드로 로직 정리
- 상품 수정 기능 구현 (`ProductRequestDTO` 재사용)
- 상품 목록 전체 조회 API 구현
- 상품 목록 페이징 및 정렬 기능 구현
- 상품 목록 검색 조건 기능 추가
- `GlobalPageRequestDTO`로 공통 페이징 요청 DTO 도입
- 상품 목록에 대한 페이징/정렬/검색 테스트 케이스 추가
- QueryDSL 설정 클래스 및 의존성 추가
- Q 클래스 Git 관리 제외 설정 (`.gitignore`)
- 정렬 유틸 클래스 `QuerydslUtils` 구현 (Pageable → OrderSpecifier 변환)
- 공통 검색 조건 유틸 `PredicateBuilder`, `SearchCondition` 도입
- 서비스 내 상품 검색 메서드 기능별로 분리 리팩토링

---

## 📌 참고 사항
- 검색 조건과 정렬 기준을 함께 사용하는 QueryDSL 기반 페이징 처리를 적용했습니다.
- 정렬 기준이 없는 경우 예외 방지를 위한 기본 처리 로직이 포함되어 있습니다.
- `PredicateBuilder` 및 `QuerydslUtils`는 다른 도메인에서도 재사용 가능한 구조로 작성되었습니다.
- 테스트 코드는 페이징/정렬/검색 조건을 통합하여 실제 목록 조회 흐름을 검증합니다.
- Q 클래스는 `.gitignore` 대상에 포함되어 있으므로, 로컬 개발 시 `generateQueryDSL` 태스크를 먼저 실행해야 합니다.
