### PR TITLE
Feat/product v3

### DIFF
--- a/back/src/main/java/org/kosa/tripTalk/common/predicate/PredicateBuilder.java
+++ b/back/src/main/java/org/kosa/tripTalk/common/predicate/PredicateBuilder.java
@@ -1,11 +1,23 @@
 package org.kosa.tripTalk.common.predicate;
 
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.ComparableExpression;
 import com.querydsl.core.types.dsl.StringPath;
 
 public class PredicateBuilder {
 	
+	// like 검색 (대소문자 구별x)
 	public static BooleanExpression applyKeyword(StringPath field, String keyword) {
 		return field.containsIgnoreCase(keyword);
+	}
+	
+	// between 범위 검색
+	// 범위안, 이상, 이하 조건
+	public static <T extends Comparable<?>> BooleanExpression between(ComparableExpression<T> field, T start, T end) {
+		if (start != null && end != null) return field.between(start, end); 
+	    if (start != null) return field.goe(start);
+	    if (end != null) return field.loe(end);
+		
+		return null;
 	}
 }

--- a/back/src/main/java/org/kosa/tripTalk/exception/ErrorResponse.java
+++ b/back/src/main/java/org/kosa/tripTalk/exception/ErrorResponse.java
@@ -1,0 +1,6 @@
+package org.kosa.tripTalk.exception;
+
+public record ErrorResponse(
+			String code,
+			String message
+		) {}

--- a/back/src/main/java/org/kosa/tripTalk/exception/GlobalExceptionHandler.java
+++ b/back/src/main/java/org/kosa/tripTalk/exception/GlobalExceptionHandler.java
@@ -1,0 +1,32 @@
+package org.kosa.tripTalk.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+	@ExceptionHandler(NotFoundException.class)
+	public  ResponseEntity<ErrorResponse> handleNotFound(NotFoundException ex) {
+		return ResponseEntity.status(HttpStatus.NOT_FOUND)
+							.body(new ErrorResponse("NOT_FOUND", ex.getMessage()));
+	}
+	
+	@ExceptionHandler(MethodArgumentNotValidException.class)
+	public ResponseEntity<ErrorResponse> handleValidationEx(MethodArgumentNotValidException ex) {
+		String message = ex.getBindingResult().getFieldError().getDefaultMessage();
+		return ResponseEntity
+							.status(HttpStatus.BAD_REQUEST)
+							.body(new ErrorResponse("INVALID_INPUT", message));
+	}
+	
+	@ExceptionHandler(Exception.class)
+	public ResponseEntity<ErrorResponse> handleEx(Exception ex) {
+		return ResponseEntity
+							.status(HttpStatus.INTERNAL_SERVER_ERROR)
+							.body(new ErrorResponse("INTERNAL_SERVER_ERROR", ex.getMessage()));
+	}
+}

--- a/back/src/main/java/org/kosa/tripTalk/exception/NotFoundException.java
+++ b/back/src/main/java/org/kosa/tripTalk/exception/NotFoundException.java
@@ -1,0 +1,7 @@
+package org.kosa.tripTalk.exception;
+
+public class NotFoundException extends RuntimeException {
+	public NotFoundException(String message) {
+		super(message);
+	}
+}

--- a/back/src/main/java/org/kosa/tripTalk/product/Product.java
+++ b/back/src/main/java/org/kosa/tripTalk/product/Product.java
@@ -63,6 +63,7 @@ public class Product {
 	@Column(nullable = false)
 	private LocalDateTime endDate;
 
+	// 수정DTO
 	public void updateFromDTO(ProductRequestDTO dto) {
 		this.title = dto.getTitle();
 		this.description = dto.getDescription();

--- a/back/src/main/java/org/kosa/tripTalk/product/Product.java
+++ b/back/src/main/java/org/kosa/tripTalk/product/Product.java
@@ -2,15 +2,19 @@ package org.kosa.tripTalk.product;
 
 import java.time.LocalDateTime;
 import org.kosa.tripTalk.category.Category;
+import org.kosa.tripTalk.product.discount.Discount;
 import org.kosa.tripTalk.seller.Seller;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -44,6 +48,9 @@ public class Product {
 	@Column(nullable = false)
 	private String description;
 
+	@OneToOne(mappedBy = "product", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+	private Discount discount;
+	
 	@Column(nullable = false)
 	private Integer price;
 
@@ -63,5 +70,21 @@ public class Product {
 		this.price = dto.getPrice();
 		this.startDate = dto.getStartDate();
 		this.endDate = dto.getEndDate();
+	}
+	
+	// 할인 가격 계산 메소드
+	public int getDiscountedPrice() {
+		if(discount != null && discount.isActive())
+			return discount.toPolicy().applyDiscount(price);
+		
+		return price;
+	}
+	
+	// 할인 적용 및 양방향 연관 관계 설정
+	// 객체지향적으로 관계를 일관되게 유지하기 위한 설계 원칙
+	public void applyDiscount(Discount discount) {
+		this.discount = discount;
+		if(discount != null)
+			discount.setProduct(this);
 	}
 }

--- a/back/src/main/java/org/kosa/tripTalk/product/ProductController.java
+++ b/back/src/main/java/org/kosa/tripTalk/product/ProductController.java
@@ -26,9 +26,9 @@ public class ProductController {
 	
 	// 등록
 	@PostMapping
-    public ResponseEntity<Void> createProduct(@RequestBody @Valid ProductRequestDTO request) {
-        productService.create(request);
-        return ResponseEntity.status(HttpStatus.CREATED).build();
+    public ResponseEntity<Long> createProduct(@RequestBody @Valid ProductRequestDTO request) {
+        Long productId = productService.create(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(productId);
     }
 
 	// 상세

--- a/back/src/main/java/org/kosa/tripTalk/product/ProductController.java
+++ b/back/src/main/java/org/kosa/tripTalk/product/ProductController.java
@@ -24,12 +24,14 @@ public class ProductController {
 
 	private final ProductService productService;
 	
+	// 등록
 	@PostMapping
     public ResponseEntity<Void> createProduct(@RequestBody @Valid ProductRequestDTO request) {
         productService.create(request);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
+	// 상세
 	@GetMapping("/{id}")
 	public ResponseEntity<ProductResponseDTO> getProduct(@PathVariable Long id) {
 		ProductResponseDTO response = productService.getProductById(id);
@@ -37,6 +39,7 @@ public class ProductController {
 		
 	}
 	
+	// 수정
 	@PutMapping("/{id}")
 	public ResponseEntity<ProductResponseDTO> updateProduct(
 			@PathVariable Long id,
@@ -46,6 +49,7 @@ public class ProductController {
 		return ResponseEntity.ok(ProductResponseDTO.from(updateProduct));
 	}
 	
+	// 리스트
 	@GetMapping
     public ResponseEntity<Page<ProductResponseDTO>> getAllProducts(
     		PageRequestDTO pageRequestDTO,

--- a/back/src/main/java/org/kosa/tripTalk/product/ProductController.java
+++ b/back/src/main/java/org/kosa/tripTalk/product/ProductController.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -24,7 +25,7 @@ public class ProductController {
 	private final ProductService productService;
 	
 	@PostMapping
-    public ResponseEntity<Void> createProduct(@RequestBody ProductRequestDTO request) {
+    public ResponseEntity<Void> createProduct(@RequestBody @Valid ProductRequestDTO request) {
         productService.create(request);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }

--- a/back/src/main/java/org/kosa/tripTalk/product/ProductPredicateBuilder.java
+++ b/back/src/main/java/org/kosa/tripTalk/product/ProductPredicateBuilder.java
@@ -7,6 +7,7 @@ import com.querydsl.core.types.dsl.BooleanExpression;
 
 public class ProductPredicateBuilder {
 	
+	// like 검색
 	public static BooleanExpression build(QProduct product, Search search) {
 		if (search == null || !search.isValid())
 			return null;

--- a/back/src/main/java/org/kosa/tripTalk/product/ProductRepositoryImpl.java
+++ b/back/src/main/java/org/kosa/tripTalk/product/ProductRepositoryImpl.java
@@ -20,6 +20,7 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
 	
 	private final JPAQueryFactory queryFactory;
 
+	// 페이징, 검색, 정렬 리스트
 	@Override
 	public Page<ProductResponseDTO> searchAll(Pageable pageable, Search search) {
 		QProduct product = QProduct.product;
@@ -32,12 +33,14 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
 		return new PageImpl<>(dtoList, pageable, total);
 	}
 
+	// dto변환
 	private List<ProductResponseDTO> toDtoList(List<Product> contents) {
 		return contents.stream()
 						.map(ProductResponseDTO::from)
 						.toList();
 	}
 
+	// 카운트
 	private Long fetchCount(QProduct product, BooleanExpression condition) {
 		return queryFactory
 						.select(product.count())
@@ -46,6 +49,7 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
 						.fetchOne();
 	}
 
+	// 내용 가져오기
 	private List<Product> fetchContent(Pageable pageable, QProduct product, BooleanExpression condition) {
 		return queryFactory
 						.selectFrom(product)

--- a/back/src/main/java/org/kosa/tripTalk/product/ProductRequestDTO.java
+++ b/back/src/main/java/org/kosa/tripTalk/product/ProductRequestDTO.java
@@ -5,6 +5,9 @@ import java.time.LocalDateTime;
 import org.kosa.tripTalk.category.Category;
 import org.kosa.tripTalk.seller.Seller;
 
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -15,13 +18,30 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 public class ProductRequestDTO {
-	private String title;
+	
+	@NotBlank(message = "제목은 필수입니다.")
+    private String title;
+
+    @NotBlank(message = "설명은 필수입니다.")
     private String description;
+
+    @NotBlank(message = "주소는 필수입니다.")
     private String address;
+
+    @NotNull(message = "가격은 필수입니다.")
+    @Min(value = 1000, message = "가격은 최소 1000원 이상이어야 합니다.")
     private Integer price;
+
+    @NotNull(message = "시작일은 필수입니다.")
     private LocalDateTime startDate;
+
+    @NotNull(message = "종료일은 필수입니다.")
     private LocalDateTime endDate;
+
+    @NotNull(message = "판매자 ID는 필수입니다.")
     private Long sellerId;
+
+    @NotNull(message = "카테고리 ID는 필수입니다.")
     private Long categoryId;
     
     public Product toEntity(Seller seller, Category category) {

--- a/back/src/main/java/org/kosa/tripTalk/product/ProductRequestDTO.java
+++ b/back/src/main/java/org/kosa/tripTalk/product/ProductRequestDTO.java
@@ -18,7 +18,8 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-@Builder
+// toBuilder = true, 생성된 객체를 바탕으로 수정한 새 객체 생성
+@Builder(toBuilder = true)
 public class ProductRequestDTO {
 	
 	@NotBlank(message = "제목은 필수입니다.")

--- a/back/src/main/java/org/kosa/tripTalk/product/ProductRequestDTO.java
+++ b/back/src/main/java/org/kosa/tripTalk/product/ProductRequestDTO.java
@@ -48,6 +48,7 @@ public class ProductRequestDTO {
     
     private DiscountDTO discount;
     
+    // 엔티티 변환
     public Product toEntity(Seller seller, Category category) {
         Product product = Product.builder()
                 .title(this.title)
@@ -60,6 +61,7 @@ public class ProductRequestDTO {
                 .category(category)
                 .build();
         
+        // 할인 엔티티로 변환
         Discount discount = DiscountDTO.toEntity(this.discount);
         if(discount != null) {
         	product.applyDiscount(discount);

--- a/back/src/main/java/org/kosa/tripTalk/product/ProductRequestDTO.java
+++ b/back/src/main/java/org/kosa/tripTalk/product/ProductRequestDTO.java
@@ -3,6 +3,8 @@ package org.kosa.tripTalk.product;
 import java.time.LocalDateTime;
 
 import org.kosa.tripTalk.category.Category;
+import org.kosa.tripTalk.product.discount.Discount;
+import org.kosa.tripTalk.product.discount.DiscountDTO;
 import org.kosa.tripTalk.seller.Seller;
 
 import jakarta.validation.constraints.Min;
@@ -44,8 +46,10 @@ public class ProductRequestDTO {
     @NotNull(message = "카테고리 ID는 필수입니다.")
     private Long categoryId;
     
+    private DiscountDTO discount;
+    
     public Product toEntity(Seller seller, Category category) {
-        return Product.builder()
+        Product product = Product.builder()
                 .title(this.title)
                 .description(this.description)
                 .address(this.address)
@@ -55,5 +59,12 @@ public class ProductRequestDTO {
                 .seller(seller)
                 .category(category)
                 .build();
+        
+        Discount discount = DiscountDTO.toEntity(this.discount);
+        if(discount != null) {
+        	product.applyDiscount(discount);
+        }
+        
+        return product;
     }
 }

--- a/back/src/main/java/org/kosa/tripTalk/product/ProductResponseDTO.java
+++ b/back/src/main/java/org/kosa/tripTalk/product/ProductResponseDTO.java
@@ -21,6 +21,7 @@ public class ProductResponseDTO {
     private String sellerName;
     private DiscountDTO discount;
     
+    // dto 폼
     public static ProductResponseDTO from(Product product) {
         return ProductResponseDTO.builder()
             .id(product.getId())

--- a/back/src/main/java/org/kosa/tripTalk/product/ProductResponseDTO.java
+++ b/back/src/main/java/org/kosa/tripTalk/product/ProductResponseDTO.java
@@ -1,5 +1,7 @@
 package org.kosa.tripTalk.product;
 
+import org.kosa.tripTalk.product.discount.DiscountDTO;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -17,6 +19,7 @@ public class ProductResponseDTO {
     private String address;
     private String categoryName;
     private String sellerName;
+    private DiscountDTO discount;
     
     public static ProductResponseDTO from(Product product) {
         return ProductResponseDTO.builder()
@@ -27,6 +30,7 @@ public class ProductResponseDTO {
             .address(product.getAddress())
             .categoryName(product.getCategory().getKind())
             .sellerName(product.getSeller().getUserid())
+            .discount(DiscountDTO.from(product.getDiscount()))
             .build();
     }
 }

--- a/back/src/main/java/org/kosa/tripTalk/product/ProductService.java
+++ b/back/src/main/java/org/kosa/tripTalk/product/ProductService.java
@@ -53,7 +53,7 @@ public class ProductService {
 	public Product update(Long id, ProductRequestDTO dto) {
 		Product product = notFoundProductId(id);
 		product.updateFromDTO(dto);
-		
+
 		return product;
 	}
 

--- a/back/src/main/java/org/kosa/tripTalk/product/ProductService.java
+++ b/back/src/main/java/org/kosa/tripTalk/product/ProductService.java
@@ -1,11 +1,9 @@
 package org.kosa.tripTalk.product;
 
-import java.util.List;
-import java.util.stream.Collectors;
-
 import org.kosa.tripTalk.category.Category;
 import org.kosa.tripTalk.category.CategoryRepository;
 import org.kosa.tripTalk.common.dto.Search;
+import org.kosa.tripTalk.exception.NotFoundException;
 import org.kosa.tripTalk.seller.Seller;
 import org.kosa.tripTalk.seller.SellerRepository;
 import org.kosa.tripTalk.user.User;
@@ -30,15 +28,15 @@ public class ProductService {
 	public void create(ProductRequestDTO request) {
 		 // 1. 판매자 유저 조회
 		User sellerUser = userRepository.findById(request.getSellerId())
-                .orElseThrow(() -> new IllegalArgumentException("판매자 유저가 존재하지 않습니다."));
+                .orElseThrow(() -> new NotFoundException("판매자 유저가 존재하지 않습니다."));
 		
 		// 2. 판매자 프로필 조회
         Seller seller = sellerRepository.findById(request.getSellerId())
-                .orElseThrow(() -> new IllegalArgumentException("판매자 프로필이 존재하지 않습니다."));
+                .orElseThrow(() -> new NotFoundException("판매자 프로필이 존재하지 않습니다."));
         
      // 3. 카테고리 조회
         Category category = categoryRepository.findById(request.getCategoryId())
-                .orElseThrow(() -> new IllegalArgumentException("카테고리가 존재하지 않습니다."));
+                .orElseThrow(() -> new NotFoundException("카테고리가 존재하지 않습니다."));
         
      // 4. 상품 생성 및 저장
         Product product = request.toEntity(seller, category);
@@ -47,17 +45,15 @@ public class ProductService {
 	}
 
 	public ProductResponseDTO getProductById(Long id) {
-		Product product = productRepository.findById(id)
-			.orElseThrow(() -> new IllegalArgumentException("해당 상품이 존재하지 않습니다."));
+		Product product = notFoundProductId(id);
+		
 		return ProductResponseDTO.from(product);
 	}
 
 	public Product update(Long id, ProductRequestDTO dto) {
-		Product product = productRepository.findById(id)
-		        .orElseThrow(() -> new IllegalArgumentException("해당 상품이 존재하지 않습니다."));
-		
+		Product product = notFoundProductId(id);
 		product.updateFromDTO(dto);
-	    
+		
 		return product;
 	}
 
@@ -65,6 +61,10 @@ public class ProductService {
 		return productRepository.searchAll(pageable, search);
 	}
 	
+	private Product notFoundProductId(Long id) {
+		return productRepository.findById(id)
+		        .orElseThrow(() -> new NotFoundException("해당 상품을 찾을 수 없습니다"));
+	}
 }
 
 

--- a/back/src/main/java/org/kosa/tripTalk/product/ProductService.java
+++ b/back/src/main/java/org/kosa/tripTalk/product/ProductService.java
@@ -26,7 +26,7 @@ public class ProductService {
 
 	// 생성
 	@Transactional
-	public void create(ProductRequestDTO request) {
+	public Long create(ProductRequestDTO request) {
 		 // 1. 판매자 유저 조회
 		User sellerUser = userRepository.findById(request.getSellerId())
                 .orElseThrow(() -> new NotFoundException("판매자 유저가 존재하지 않습니다."));
@@ -43,6 +43,8 @@ public class ProductService {
         Product product = request.toEntity(seller, category);
         
         productRepository.save(product);
+        
+        return product.getId();
 	}
 
 	// 상세

--- a/back/src/main/java/org/kosa/tripTalk/product/ProductService.java
+++ b/back/src/main/java/org/kosa/tripTalk/product/ProductService.java
@@ -24,6 +24,7 @@ public class ProductService {
 	private final UserRepository userRepository;
 	private final CategoryRepository categoryRepository;
 
+	// 생성
 	@Transactional
 	public void create(ProductRequestDTO request) {
 		 // 1. 판매자 유저 조회
@@ -44,12 +45,14 @@ public class ProductService {
         productRepository.save(product);
 	}
 
+	// 상세
 	public ProductResponseDTO getProductById(Long id) {
 		Product product = notFoundProductId(id);
 		
 		return ProductResponseDTO.from(product);
 	}
 
+	// 수정
 	public Product update(Long id, ProductRequestDTO dto) {
 		Product product = notFoundProductId(id);
 		product.updateFromDTO(dto);
@@ -57,10 +60,12 @@ public class ProductService {
 		return product;
 	}
 
+	// 리스트
 	public Page<ProductResponseDTO> getAllProducts(Pageable pageable, Search search) {
 		return productRepository.searchAll(pageable, search);
 	}
 	
+	// 없는 상품 예외
 	private Product notFoundProductId(Long id) {
 		return productRepository.findById(id)
 		        .orElseThrow(() -> new NotFoundException("해당 상품을 찾을 수 없습니다"));

--- a/back/src/main/java/org/kosa/tripTalk/product/discount/Discount.java
+++ b/back/src/main/java/org/kosa/tripTalk/product/discount/Discount.java
@@ -1,0 +1,69 @@
+package org.kosa.tripTalk.product.discount;
+
+import java.time.LocalDateTime;
+
+import org.kosa.tripTalk.product.Product;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity
+public class Discount {
+	@Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id")
+    private Product product;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private DiscountType discountType; // FIXED, RATE, NONE
+
+    private Integer discountAmount; // 정액 할인용 (예: 1000)
+    private Double discountRate;    // 정률 할인용 (예: 0.1)
+
+    @Column(nullable = false)
+    private String name; // 예: "6월 특가"
+
+    @Column(nullable = false)
+    private LocalDateTime startAt;
+
+    @Column(nullable = false)
+    private LocalDateTime endAt;
+    
+    // 할인 유효 기간 여부 판단
+    public boolean isActive() {
+    	LocalDateTime now = LocalDateTime.now();
+    	return now.isAfter(startAt) && now.isBefore(endAt);
+    }
+    
+    // 할인 타입에 따라 해당 전략 객체 직접 반환
+    // 추후 정책이 복잡해질 경우 별도 Factory 클래스로 리팩토링
+    public DiscountPolicy toPolicy() {
+    	if (discountType == null) return price -> price;
+    	
+    	return switch (discountType) {
+    		case FIXED -> new FixedDiscountPolicy(discountAmount);
+    		case RATE -> new RateDiscountPolicy(discountRate);
+    		default -> price -> price;
+    	};
+    }
+}

--- a/back/src/main/java/org/kosa/tripTalk/product/discount/Discount.java
+++ b/back/src/main/java/org/kosa/tripTalk/product/discount/Discount.java
@@ -13,7 +13,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -29,7 +29,7 @@ public class Discount {
     @GeneratedValue(strategy = GenerationType.SEQUENCE)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "product_id")
     private Product product;
 
@@ -66,4 +66,10 @@ public class Discount {
     		default -> price -> price;
     	};
     }
+
+    // 방향 연관관계를 맞추기 위해 사용
+    // product 엔티티의 applyDiscount() 내부에서 호출됨
+	public void setProduct(Product product) {
+		this.product = product;
+	}
 }

--- a/back/src/main/java/org/kosa/tripTalk/product/discount/DiscountDTO.java
+++ b/back/src/main/java/org/kosa/tripTalk/product/discount/DiscountDTO.java
@@ -1,0 +1,47 @@
+package org.kosa.tripTalk.product.discount;
+
+import java.time.LocalDateTime;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@Builder
+@AllArgsConstructor
+public class DiscountDTO {
+	private DiscountType discountType;
+    private Integer discountAmount;
+    private Double discountRate;
+    private String name;
+    private LocalDateTime startAt;
+    private LocalDateTime endAt;
+    
+    public static DiscountDTO from(Discount discount) {
+        if (discount == null) return null;
+
+        return DiscountDTO.builder()
+                .discountType(discount.getDiscountType())
+                .discountAmount(discount.getDiscountAmount())
+                .discountRate(discount.getDiscountRate())
+                .name(discount.getName())
+                .startAt(discount.getStartAt())
+                .endAt(discount.getEndAt())
+                .build();
+    }
+    
+    public static Discount toEntity(DiscountDTO dto) {
+        if (dto == null) return null;
+
+        return Discount.builder()
+                .discountType(dto.getDiscountType())
+                .discountAmount(dto.getDiscountAmount())
+                .discountRate(dto.getDiscountRate())
+                .name(dto.getName())
+                .startAt(dto.getStartAt())
+                .endAt(dto.getEndAt())
+                .build();
+    }
+}

--- a/back/src/main/java/org/kosa/tripTalk/product/discount/DiscountDTO.java
+++ b/back/src/main/java/org/kosa/tripTalk/product/discount/DiscountDTO.java
@@ -19,6 +19,7 @@ public class DiscountDTO {
     private LocalDateTime startAt;
     private LocalDateTime endAt;
     
+    // dto 변환
     public static DiscountDTO from(Discount discount) {
         if (discount == null) return null;
 
@@ -32,6 +33,7 @@ public class DiscountDTO {
                 .build();
     }
     
+    // 엔티티 변환
     public static Discount toEntity(DiscountDTO dto) {
         if (dto == null) return null;
 

--- a/back/src/main/java/org/kosa/tripTalk/product/discount/DiscountPolicy.java
+++ b/back/src/main/java/org/kosa/tripTalk/product/discount/DiscountPolicy.java
@@ -1,5 +1,6 @@
 package org.kosa.tripTalk.product.discount;
 
+// 할인 정책 인터페이스
 public interface DiscountPolicy {
 	int applyDiscount(int price);
 }

--- a/back/src/main/java/org/kosa/tripTalk/product/discount/DiscountPolicy.java
+++ b/back/src/main/java/org/kosa/tripTalk/product/discount/DiscountPolicy.java
@@ -1,0 +1,5 @@
+package org.kosa.tripTalk.product.discount;
+
+public interface DiscountPolicy {
+	int applyDiscount(int price);
+}

--- a/back/src/main/java/org/kosa/tripTalk/product/discount/DiscountType.java
+++ b/back/src/main/java/org/kosa/tripTalk/product/discount/DiscountType.java
@@ -3,6 +3,7 @@ package org.kosa.tripTalk.product.discount;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+// db 안쓰고 고정 값 할인 타입
 @RequiredArgsConstructor
 @Getter
 public enum DiscountType {

--- a/back/src/main/java/org/kosa/tripTalk/product/discount/DiscountType.java
+++ b/back/src/main/java/org/kosa/tripTalk/product/discount/DiscountType.java
@@ -1,0 +1,14 @@
+package org.kosa.tripTalk.product.discount;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum DiscountType {
+	FIXED("정액 할인"),   // 예: 1,000원 할인
+    RATE("정률 할인"),    // 예: 10% 할인
+    NONE("할인 없음");    // 할인 미적용
+	
+	  private final String label;
+}

--- a/back/src/main/java/org/kosa/tripTalk/product/discount/FixedDiscountPolicy.java
+++ b/back/src/main/java/org/kosa/tripTalk/product/discount/FixedDiscountPolicy.java
@@ -2,6 +2,7 @@ package org.kosa.tripTalk.product.discount;
 
 import lombok.RequiredArgsConstructor;
 
+// 고정할인
 @RequiredArgsConstructor
 public class FixedDiscountPolicy implements DiscountPolicy {
 	

--- a/back/src/main/java/org/kosa/tripTalk/product/discount/FixedDiscountPolicy.java
+++ b/back/src/main/java/org/kosa/tripTalk/product/discount/FixedDiscountPolicy.java
@@ -1,0 +1,14 @@
+package org.kosa.tripTalk.product.discount;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class FixedDiscountPolicy implements DiscountPolicy {
+	
+	private final int discountAmount;
+
+	@Override
+	public int applyDiscount(int price) {
+		return price -discountAmount;
+	}
+}

--- a/back/src/main/java/org/kosa/tripTalk/product/discount/RateDiscountPolicy.java
+++ b/back/src/main/java/org/kosa/tripTalk/product/discount/RateDiscountPolicy.java
@@ -1,0 +1,15 @@
+package org.kosa.tripTalk.product.discount;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class RateDiscountPolicy implements DiscountPolicy {
+
+	private final double rate;
+	
+	@Override
+	public int applyDiscount(int price) {
+		return (int)(price * (1 -rate));
+	}
+
+}

--- a/back/src/main/java/org/kosa/tripTalk/product/discount/RateDiscountPolicy.java
+++ b/back/src/main/java/org/kosa/tripTalk/product/discount/RateDiscountPolicy.java
@@ -2,6 +2,7 @@ package org.kosa.tripTalk.product.discount;
 
 import lombok.RequiredArgsConstructor;
 
+// 퍼센트 할인
 @RequiredArgsConstructor
 public class RateDiscountPolicy implements DiscountPolicy {
 

--- a/back/src/test/java/org/kosa/tripTalk/JwtTestConfig.java
+++ b/back/src/test/java/org/kosa/tripTalk/JwtTestConfig.java
@@ -1,0 +1,27 @@
+package org.kosa.tripTalk;
+
+import org.kosa.tripTalk.jwt.JwtUtil;
+import org.kosa.tripTalk.product.ProductService;
+import org.kosa.tripTalk.user.UserService;
+import org.mockito.Mockito;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+@TestConfiguration
+public class JwtTestConfig {
+	
+	@Bean
+	JwtUtil jwtUtil() {
+		return Mockito.mock(JwtUtil.class);
+	}
+	
+	@Bean
+    UserService userService() {
+        return Mockito.mock(UserService.class);
+    }
+	
+	@Bean
+    ProductService productService() {
+        return Mockito.mock(ProductService.class);
+    }
+}

--- a/back/src/test/java/org/kosa/tripTalk/product/ProductControllerTest.java
+++ b/back/src/test/java/org/kosa/tripTalk/product/ProductControllerTest.java
@@ -1,0 +1,70 @@
+package org.kosa.tripTalk.product;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@WebMvcTest(ProductController.class)
+class ProductControllerTest {
+	
+	@Autowired
+	private MockMvc mockMvc;
+	
+	@Autowired
+	private ObjectMapper objectMapper;
+	
+	@Test
+    @DisplayName("상품 등록 실패 - 제목 없음 (@NotBlank)")
+    void createProduct_fail_whenTitleIsBlank() throws Exception {
+		ProductRequestDTO request = ProductRequestDTO.builder()
+		        .title("") // @NotBlank 위반
+		        .description("설명입니다")
+		        .address("서울시")
+		        .price(10000)
+		        .startDate(LocalDateTime.of(2025, 7, 1, 10, 0))
+		        .endDate(LocalDateTime.of(2025, 7, 10, 10, 0))
+		        .sellerId(1L)
+		        .categoryId(1L)
+		        .build();
+
+        mockMvc.perform(post("/api/product")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("INVALID_INPUT"))
+                .andExpect(jsonPath("$.message").exists());
+    }
+	
+	@Test
+    @DisplayName("상품 등록 실패 - 가격이 0원 (@Min)")
+    void createProduct_fail_whenPriceIsZero() throws Exception {
+		ProductRequestDTO request = ProductRequestDTO.builder()
+		        .title("제목입니다")
+		        .description("설명입니다")
+		        .price(0) // 실패 테스트용
+		        .address("서울")
+		        .sellerId(1L)
+		        .categoryId(1L)
+		        .startDate(LocalDateTime.of(2025, 7, 1, 0, 0))
+		        .endDate(LocalDateTime.of(2025, 7, 10, 0, 0))
+		        .build();
+
+        mockMvc.perform(post("/api/product")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("INVALID_INPUT"))
+                .andExpect(jsonPath("$.message").exists());
+    }
+}

--- a/back/src/test/java/org/kosa/tripTalk/product/ProductControllerTest.java
+++ b/back/src/test/java/org/kosa/tripTalk/product/ProductControllerTest.java
@@ -8,14 +8,22 @@ import java.time.LocalDateTime;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.kosa.tripTalk.JwtTestConfig;
+import org.kosa.tripTalk.exception.GlobalExceptionHandler;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+@AutoConfigureMockMvc(addFilters = false)
 @WebMvcTest(ProductController.class)
+@ActiveProfiles("test")
+@Import({JwtTestConfig.class, GlobalExceptionHandler.class})
 class ProductControllerTest {
 	
 	@Autowired

--- a/back/src/test/java/org/kosa/tripTalk/product/ProductServiceTest.java
+++ b/back/src/test/java/org/kosa/tripTalk/product/ProductServiceTest.java
@@ -1,6 +1,7 @@
 package org.kosa.tripTalk.product;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -12,6 +13,7 @@ import org.kosa.tripTalk.category.Category;
 import org.kosa.tripTalk.category.CategoryRepository;
 import org.kosa.tripTalk.common.dto.PageRequestDTO;
 import org.kosa.tripTalk.common.dto.Search;
+import org.kosa.tripTalk.exception.NotFoundException;
 import org.kosa.tripTalk.seller.Seller;
 import org.kosa.tripTalk.seller.SellerRepository;
 import org.kosa.tripTalk.user.User;
@@ -164,5 +166,15 @@ class ProductServiceTest {
 	    assertThat(result.isFirst()).isTrue();                       // 첫 페이지
 	    assertThat(result.isLast()).isFalse();                       // 아직 마지막 아님
 	    assertThat(result.getContent().get(0).getPrice()).isEqualTo(10000); // 정렬 확인 (오름차순)
+	}
+	
+	@DisplayName("상품 조회 실패 - 존재하지 않는 ID")
+	@Test
+	void getProduct_fail_whenProductNotFound() {
+	    Long invalidId = 9999L;
+
+	    assertThatThrownBy(() -> productService.getProductById(invalidId))
+	        .isInstanceOf(NotFoundException.class)
+	        .hasMessageContaining("해당 상품을 찾을 수 없습니다");
 	}
 }

--- a/back/src/test/java/org/kosa/tripTalk/product/ProductServiceTest.java
+++ b/back/src/test/java/org/kosa/tripTalk/product/ProductServiceTest.java
@@ -14,6 +14,8 @@ import org.kosa.tripTalk.category.CategoryRepository;
 import org.kosa.tripTalk.common.dto.PageRequestDTO;
 import org.kosa.tripTalk.common.dto.Search;
 import org.kosa.tripTalk.exception.NotFoundException;
+import org.kosa.tripTalk.product.discount.DiscountDTO;
+import org.kosa.tripTalk.product.discount.DiscountType;
 import org.kosa.tripTalk.seller.Seller;
 import org.kosa.tripTalk.seller.SellerRepository;
 import org.kosa.tripTalk.user.User;
@@ -46,7 +48,7 @@ class ProductServiceTest {
     private Seller savedSeller;
     private Category savedCategory;
 
-	@BeforeEach
+    @BeforeEach
     void setup() {
         savedUser = userRepository.save(User.builder()
                 .userId("user123")
@@ -60,7 +62,7 @@ class ProductServiceTest {
 
         savedSeller = sellerRepository.save(Seller.builder()
                 .user(savedUser)
-                .userid(savedUser.getUserId())         // 별도로 저장하는 문자열
+                .userid(savedUser.getUserId())
                 .businessNumber("111-22-33333")
                 .businessName("길동상점")
                 .contact("070-1234-5678")
@@ -72,109 +74,138 @@ class ProductServiceTest {
                 .iconUrl("https://example.com/default.png")
                 .build());
     }
-	
-	@Test
+
+    @Test
     @DisplayName("정상 상품 등록")
     void createProduct_success() {
-        // given
-        ProductRequestDTO request = ProductRequestDTO.builder()
-                .title("제주도 여행")
-                .description("힐링 3박 4일")
-                .address("제주특별자치도 제주시")
-                .price(299000)
-                .startDate(LocalDateTime.now().plusDays(3))
-                .endDate(LocalDateTime.now().plusDays(6))
-                .sellerId(savedUser.getId())
-                .categoryId(savedCategory.getId())
-                .build();
+        ProductRequestDTO request = createProductRequest(
+                "제주도 여행", "힐링 3박 4일", 299000,
+                LocalDateTime.now().plusDays(3), LocalDateTime.now().plusDays(6)
+        );
 
-        // when
         productService.create(request);
 
-        // then
         List<Product> result = productRepository.findAll();
         assertThat(result).hasSize(1);
         assertThat(result.get(0).getTitle()).isEqualTo("제주도 여행");
     }
 
-	@Test
-	@DisplayName("상품 정상 수정")
-	void updateProduct_success() {
-	    // given
-	    Product savedProduct = productRepository.save(Product.builder()
-	            .title("기존 제목")
-	            .description("기존 설명")
-	            .address("서울시 강남구")
-	            .price(100000)
-	            .startDate(LocalDateTime.now().plusDays(5))
-	            .endDate(LocalDateTime.now().plusDays(7))
-	            .category(savedCategory)
-	            .seller(savedSeller)
-	            .build());
+    @Test
+    @DisplayName("상품 정상 수정")
+    void updateProduct_success() {
+        Product savedProduct = saveProduct("기존 제목", 100000);
 
-	    ProductRequestDTO updateDto = ProductRequestDTO.builder()
-	            .title("수정된 제목")
-	            .description("수정된 설명")
-	            .address("부산 해운대")
-	            .price(200000)
-	            .startDate(LocalDateTime.now().plusDays(10))
-	            .endDate(LocalDateTime.now().plusDays(13))
-	            .build();
+        ProductRequestDTO updateDto = createProductRequest(
+                "수정된 제목", "수정된 설명", 200000,
+                LocalDateTime.now().plusDays(10), LocalDateTime.now().plusDays(13)
+        );
 
-	    // when
-	    productService.update(savedProduct.getId(), updateDto);
+        productService.update(savedProduct.getId(), updateDto);
 
-	    // then
-	    Product updatedProduct = productRepository.findById(savedProduct.getId()).orElseThrow();
-	    assertThat(updatedProduct.getTitle()).isEqualTo("수정된 제목");
-	    assertThat(updatedProduct.getAddress()).isEqualTo("부산 해운대");
-	    assertThat(updatedProduct.getPrice()).isEqualTo(200000);
-	}
-	
-	@Test
-	@DisplayName("상품 목록 페이징 + 정렬 + 검색 조회 성공")
-	void getAllProducts_withPagingSortingAndSearch_success() {
-	    // given: 15개의 상품 등록
-	    for (int i = 1; i <= 15; i++) {
-	        productRepository.save(Product.builder()
-	                .title("제주 상품 " + i)
-	                .description("힐링 설명 " + i)
-	                .address("주소" + i)
-	                .price(10000 * i)
-	                .startDate(LocalDateTime.now().plusDays(i))
-	                .endDate(LocalDateTime.now().plusDays(i + 2))
-	                .category(savedCategory)
-	                .seller(savedSeller)
-	                .build());
-	    }
+        Product updated = productRepository.findById(savedProduct.getId()).orElseThrow();
+        assertThat(updated.getTitle()).isEqualTo("수정된 제목");
+        assertThat(updated.getAddress()).isEqualTo("기본 주소");
+        assertThat(updated.getPrice()).isEqualTo(200000);
+    }
 
-	    PageRequestDTO pageRequestDTO = new PageRequestDTO(1, 10, "price,asc");
-	    Pageable pageable = pageRequestDTO.toPageable();
+    @Test
+    @DisplayName("상품 목록 페이징 + 정렬 + 검색 조회 성공")
+    void getAllProducts_withPagingSortingAndSearch_success() {
+        for (int i = 1; i <= 15; i++) {
+            saveProduct("제주 상품 " + i, 10000 * i);
+        }
 
-	    // 검색 조건: title에 "제주" 포함
-		Search search = new Search();
-	    search.setSearchKey("title");
-	    search.setSearchValue("제주");
+        PageRequestDTO pageRequestDTO = new PageRequestDTO(1, 10, "price,asc");
+        Pageable pageable = pageRequestDTO.toPageable();
 
-	    // when
-	    Page<ProductResponseDTO> result = productService.getAllProducts(pageable, search);
+        Search search = new Search();
+        search.setSearchKey("title");
+        search.setSearchValue("제주");
 
-	    // then
-	    assertThat(result.getContent()).hasSize(10);                 // 1페이지에 10개
-	    assertThat(result.getTotalElements()).isEqualTo(15);         // 총 15개 중 모두 "제주" 포함
-	    assertThat(result.getTotalPages()).isEqualTo(2);             // 총 2페이지
-	    assertThat(result.isFirst()).isTrue();                       // 첫 페이지
-	    assertThat(result.isLast()).isFalse();                       // 아직 마지막 아님
-	    assertThat(result.getContent().get(0).getPrice()).isEqualTo(10000); // 정렬 확인 (오름차순)
-	}
-	
-	@DisplayName("상품 조회 실패 - 존재하지 않는 ID")
-	@Test
-	void getProduct_fail_whenProductNotFound() {
-	    Long invalidId = 9999L;
+        Page<ProductResponseDTO> result = productService.getAllProducts(pageable, search);
 
-	    assertThatThrownBy(() -> productService.getProductById(invalidId))
-	        .isInstanceOf(NotFoundException.class)
-	        .hasMessageContaining("해당 상품을 찾을 수 없습니다");
-	}
+        assertThat(result.getContent()).hasSize(10);
+        assertThat(result.getTotalElements()).isEqualTo(15);
+        assertThat(result.getTotalPages()).isEqualTo(2);
+        assertThat(result.isFirst()).isTrue();
+        assertThat(result.isLast()).isFalse();
+        assertThat(result.getContent().get(0).getPrice()).isEqualTo(10000);
+    }
+
+    @Test
+    @DisplayName("상품 조회 실패 - 존재하지 않는 ID")
+    void getProduct_fail_whenProductNotFound() {
+        Long invalidId = 9999L;
+
+        assertThatThrownBy(() -> productService.getProductById(invalidId))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessageContaining("해당 상품을 찾을 수 없습니다");
+    }
+
+    @Test
+    @DisplayName("상품 수정 시 할인 정보도 변경된다")
+    void updateProduct_discountOnly() {
+        DiscountDTO discount1 = createDiscountDTO(DiscountType.FIXED, 5000, 0, "초기 프로모션", 7);
+
+        ProductRequestDTO request = createProductRequest(
+                "부산 여행", "기존 상품", 150000,
+                LocalDateTime.now().plusDays(2), LocalDateTime.now().plusDays(5)
+        ).toBuilder().discount(discount1).build();
+
+        Long productId = productService.create(request);
+
+        DiscountDTO discount2 = createDiscountDTO(DiscountType.RATE, 0, 0.2, "20% 여름 할인", 10);
+
+        ProductRequestDTO updateDTO = createProductRequest(
+                "부산 여행", "기존 상품", 150000,
+                request.getStartDate(), request.getEndDate()
+        ).toBuilder().discount(discount2).build();
+
+        productService.update(productId, updateDTO);
+
+        Product updated = productRepository.findById(productId).orElseThrow();
+        assertThat(updated.getDiscount().getDiscountType()).isEqualTo(DiscountType.RATE);
+        assertThat(updated.getDiscountedPrice()).isEqualTo(120000);
+        assertThat(updated.getDiscount().getName()).isEqualTo("20% 여름 할인");
+    }
+
+    // ========== 공통 유틸 메서드 ==========
+
+    private ProductRequestDTO createProductRequest(String title, String description, int price, LocalDateTime start, LocalDateTime end) {
+        return ProductRequestDTO.builder()
+                .title(title)
+                .description(description)
+                .address("기본 주소")
+                .price(price)
+                .startDate(start)
+                .endDate(end)
+                .sellerId(savedUser.getId())
+                .categoryId(savedCategory.getId())
+                .build();
+    }
+
+    private Product saveProduct(String title, int price) {
+        return productRepository.save(Product.builder()
+                .title(title)
+                .description("기본 설명")
+                .address("기본 주소")
+                .price(price)
+                .startDate(LocalDateTime.now().plusDays(1))
+                .endDate(LocalDateTime.now().plusDays(3))
+                .category(savedCategory)
+                .seller(savedSeller)
+                .build());
+    }
+
+    private DiscountDTO createDiscountDTO(DiscountType type, int amount, double rate, String name, int plusDays) {
+        return DiscountDTO.builder()
+                .discountType(type)
+                .discountAmount(amount)
+                .discountRate(rate)
+                .name(name)
+                .startAt(LocalDateTime.now().minusDays(1))
+                .endAt(LocalDateTime.now().plusDays(plusDays))
+                .build();
+    }
+
 }

--- a/back/src/test/java/org/kosa/tripTalk/product/ProductTest.java
+++ b/back/src/test/java/org/kosa/tripTalk/product/ProductTest.java
@@ -1,0 +1,82 @@
+package org.kosa.tripTalk.product;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.kosa.tripTalk.product.discount.Discount;
+import org.kosa.tripTalk.product.discount.DiscountType;
+
+@DisplayName("상품 할인 가격 계산 테스트")
+class ProductTest {
+
+	@Test
+    @DisplayName("할인 정보가 없으면 원래 가격 반환")
+    void noDiscount() {
+        Product product = Product.builder()
+                .price(10000)
+                .build();
+
+        assertThat(product.getDiscountedPrice()).isEqualTo(10000);
+    }
+
+    @Test
+    @DisplayName("정액 할인 적용")
+    void fixedDiscount() {
+        Discount discount = Discount.builder()
+                .discountType(DiscountType.FIXED)
+                .discountAmount(2000)
+                .startAt(LocalDateTime.now().minusDays(1))
+                .endAt(LocalDateTime.now().plusDays(1))
+                .build();
+
+        Product product = Product.builder()
+                .price(10000)
+                .build();
+
+        product.setDiscount(discount); // 연관관계 메서드 사용
+
+        assertThat(product.getDiscountedPrice()).isEqualTo(8000);
+    }
+
+    @Test
+    @DisplayName("정률 할인 적용")
+    void rateDiscount() {
+        Discount discount = Discount.builder()
+                .discountType(DiscountType.RATE)
+                .discountRate(0.1)
+                .startAt(LocalDateTime.now().minusDays(1))
+                .endAt(LocalDateTime.now().plusDays(1))
+                .build();
+
+        Product product = Product.builder()
+                .price(20000)
+                .build();
+
+        product.setDiscount(discount);
+
+        assertThat(product.getDiscountedPrice()).isEqualTo(18000);
+    }
+
+    @Test
+    @DisplayName("할인 기간이 아니면 원래 가격 반환")
+    void inactiveDiscount() {
+        Discount discount = Discount.builder()
+                .discountType(DiscountType.FIXED)
+                .discountAmount(1000)
+                .startAt(LocalDateTime.now().minusDays(10))
+                .endAt(LocalDateTime.now().minusDays(5))
+                .build();
+
+        Product product = Product.builder()
+                .price(15000)
+                .build();
+
+        product.setDiscount(discount);
+
+        assertThat(product.getDiscountedPrice()).isEqualTo(15000);
+    }
+
+}

--- a/back/src/test/java/org/kosa/tripTalk/product/discount/DiscountPolicyTest.java
+++ b/back/src/test/java/org/kosa/tripTalk/product/discount/DiscountPolicyTest.java
@@ -1,0 +1,33 @@
+package org.kosa.tripTalk.product.discount;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("할인 정책 테스트")
+class DiscountPolicyTest {
+
+	@Test
+    @DisplayName("정액 할인: 1,000원 할인")
+    void fixedDiscount() {
+        DiscountPolicy policy = new FixedDiscountPolicy(1000);
+        assertThat(policy.applyDiscount(10000)).isEqualTo(9000);
+    }
+
+    @Test
+    @DisplayName("정률 할인: 20% 할인")
+    void rateDiscount() {
+        DiscountPolicy policy = new RateDiscountPolicy(0.2);
+        assertThat(policy.applyDiscount(10000)).isEqualTo(8000);
+    }
+
+    @Test
+    @DisplayName("할인 없음: 그대로 가격")
+    void noDiscount() {
+        DiscountPolicy policy = price -> price;
+        assertThat(policy.applyDiscount(15000)).isEqualTo(15000);
+    }
+
+}

--- a/back/src/test/java/org/kosa/tripTalk/product/discount/DiscountTest.java
+++ b/back/src/test/java/org/kosa/tripTalk/product/discount/DiscountTest.java
@@ -1,5 +1,6 @@
 package org.kosa.tripTalk.product.discount;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
 import org.junit.jupiter.api.DisplayName;

--- a/back/src/test/java/org/kosa/tripTalk/product/discount/DiscountTest.java
+++ b/back/src/test/java/org/kosa/tripTalk/product/discount/DiscountTest.java
@@ -1,0 +1,52 @@
+package org.kosa.tripTalk.product.discount;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Discount → DiscountPolicy 변환 테스트")
+class DiscountTest {
+
+	@Test
+    @DisplayName("정액 할인 전략 반환 확인")
+    void toPolicy_fixed() {
+        Discount discount = Discount.builder()
+                .discountType(DiscountType.FIXED)
+                .discountAmount(1000)
+                .build();
+
+        DiscountPolicy policy = discount.toPolicy();
+        int discounted = policy.applyDiscount(10000);
+
+        assertThat(discounted).isEqualTo(9000);
+    }
+
+    @Test
+    @DisplayName("정률 할인 전략 반환 확인")
+    void toPolicy_rate() {
+        Discount discount = Discount.builder()
+                .discountType(DiscountType.RATE)
+                .discountRate(0.2)
+                .build();
+
+        DiscountPolicy policy = discount.toPolicy();
+        int discounted = policy.applyDiscount(10000);
+
+        assertThat(discounted).isEqualTo(8000);
+    }
+
+    @Test
+    @DisplayName("할인 없음 처리")
+    void toPolicy_none() {
+        Discount discount = Discount.builder()
+                .discountType(DiscountType.NONE)
+                .build();
+
+        DiscountPolicy policy = discount.toPolicy();
+        int discounted = policy.applyDiscount(10000);
+
+        assertThat(discounted).isEqualTo(10000);
+    }
+
+}


### PR DESCRIPTION
## 🔧 작업 내용
- 전역 예외 처리 구조 및 공통 예외 클래스(`NotFoundException` 등) 추가
- 상품 등록 요청 DTO에 유효성 검사 어노테이션 추가 (@NotBlank, @Min 등)
- 상품 등록/조회 실패 케이스에 대한 테스트 코드 추가
- 상품 조회 실패 시 예외 처리 로직 개선 및 중복 코드 제거
- 테스트 환경에서 JWT 비활성화를 위한 설정 구성 (`@AutoConfigureMockMvc`, `@Import`)
- QueryDSL 범위 검색 유틸 메서드 `between()` 구현
- 할인 정책(정액/정율) 인터페이스 및 구현 클래스 설계
- DiscountType enum 및 Discount 엔티티 추가
- 상품과 할인 간 연관관계 설정 및 할인 가격 계산 로직 구현
- 상품 등록 및 상세 조회 시 할인 정보 반영 기능 추가
- 할인 정책 및 할인 계산 메서드 단위 테스트 추가
- 주요 서비스 및 유틸 클래스에 설명 주석 추가

## 📌 참고 사항
- 기능 구현은 TDD 방식으로 단위 테스트와 함께 진행되었습니다
- 할인 정책은 전략 패턴 기반이며, `Product.getDiscountedPrice()`에서 적용됩니다
- 예외 처리는 전역 핸들러(`@ControllerAdvice`) 기반으로 응답 포맷을 통일했습니다
- 로직 변경은 없지만 주석 추가로 가독성을 개선했습니다
