### PR TITLE
Feat/seller

### DIFF
--- a/back/src/main/java/org/kosa/tripTalk/product/Product.java
+++ b/back/src/main/java/org/kosa/tripTalk/product/Product.java
@@ -3,6 +3,7 @@ package org.kosa.tripTalk.product;
 import java.time.LocalDateTime;
 import org.kosa.tripTalk.category.Category;
 import org.kosa.tripTalk.product.discount.Discount;
+import org.kosa.tripTalk.product.discount.DiscountDTO;
 import org.kosa.tripTalk.seller.Seller;
 
 import jakarta.persistence.CascadeType;
@@ -71,6 +72,10 @@ public class Product {
 		this.price = dto.getPrice();
 		this.startDate = dto.getStartDate();
 		this.endDate = dto.getEndDate();
+		
+		Discount discount = DiscountDTO.toEntity(dto.getDiscount());
+		// 할인 적용
+		this.applyDiscount(discount);
 	}
 	
 	// 할인 가격 계산 메소드

--- a/back/src/main/java/org/kosa/tripTalk/product/ProductRepositoryImpl.java
+++ b/back/src/main/java/org/kosa/tripTalk/product/ProductRepositoryImpl.java
@@ -2,8 +2,11 @@ package org.kosa.tripTalk.product;
 
 import java.util.List;
 
+import org.kosa.tripTalk.category.QCategory;
 import org.kosa.tripTalk.common.dto.Search;
 import org.kosa.tripTalk.common.querydsl.QuerydslUtils;
+import org.kosa.tripTalk.product.discount.QDiscount;
+import org.kosa.tripTalk.seller.QSeller;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
@@ -53,6 +56,10 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
 	private List<Product> fetchContent(Pageable pageable, QProduct product, BooleanExpression condition) {
 		return queryFactory
 						.selectFrom(product)
+						// 연관 엔티티를 지연 로딩하지 않고 즉시 함께 가져옴
+						.leftJoin(product.discount, QDiscount.discount).fetchJoin()
+						.leftJoin(product.category, QCategory.category).fetchJoin()
+						.leftJoin(product.seller, QSeller.seller).fetchJoin()
 						.where(condition)
 						.offset(pageable.getOffset())
 						.limit(pageable.getPageSize())

--- a/back/src/main/java/org/kosa/tripTalk/product/ProductResponseDTO.java
+++ b/back/src/main/java/org/kosa/tripTalk/product/ProductResponseDTO.java
@@ -20,6 +20,7 @@ public class ProductResponseDTO {
     private String categoryName;
     private String sellerName;
     private DiscountDTO discount;
+    private int discountedPrice;
     
     // dto 폼
     public static ProductResponseDTO from(Product product) {
@@ -32,6 +33,7 @@ public class ProductResponseDTO {
             .categoryName(product.getCategory().getKind())
             .sellerName(product.getSeller().getUserid())
             .discount(DiscountDTO.from(product.getDiscount()))
+            .discountedPrice(product.getDiscountedPrice())
             .build();
     }
 }

--- a/back/src/main/java/org/kosa/tripTalk/product/ProductService.java
+++ b/back/src/main/java/org/kosa/tripTalk/product/ProductService.java
@@ -55,6 +55,7 @@ public class ProductService {
 	}
 
 	// 수정
+	@Transactional
 	public Product update(Long id, ProductRequestDTO dto) {
 		Product product = notFoundProductId(id);
 		product.updateFromDTO(dto);

--- a/back/src/main/java/org/kosa/tripTalk/seller/DailySaleDTO.java
+++ b/back/src/main/java/org/kosa/tripTalk/seller/DailySaleDTO.java
@@ -1,0 +1,8 @@
+package org.kosa.tripTalk.seller;
+
+import java.time.LocalDateTime;
+
+//  일별 매출 DTO (x축: LocalDate, y축: amount)
+public record DailySaleDTO(LocalDateTime date, long amount) {
+
+}

--- a/back/src/main/java/org/kosa/tripTalk/seller/GroupedSaleDTO.java
+++ b/back/src/main/java/org/kosa/tripTalk/seller/GroupedSaleDTO.java
@@ -1,0 +1,6 @@
+package org.kosa.tripTalk.seller;
+
+// 월별/연도별 매출 DTO (x축: key = "2025-06", "2025", y축: amount)
+public record GroupedSaleDTO(String key, long amount) {
+
+}

--- a/back/src/main/java/org/kosa/tripTalk/seller/Seller.java
+++ b/back/src/main/java/org/kosa/tripTalk/seller/Seller.java
@@ -3,8 +3,6 @@ import org.kosa.tripTalk.user.User;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.MapsId;

--- a/back/src/main/java/org/kosa/tripTalk/seller/SellerController.java
+++ b/back/src/main/java/org/kosa/tripTalk/seller/SellerController.java
@@ -1,11 +1,34 @@
 package org.kosa.tripTalk.seller;
 
+import java.time.LocalDate;
+
+import org.kosa.tripTalk.user.User;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/api/seller")
 public class SellerController {
 	private final SellerService sellerService;
+	
+	// 판매자 매출 통계 조회 (일/월/연 단위)
+    @GetMapping("/sales")
+    public ResponseEntity<?> getSales(
+            @RequestParam LocalDate start,
+            @RequestParam LocalDate end,
+            @RequestParam(defaultValue = "daily") String unit,
+            @AuthenticationPrincipal User user
+    ) {
+
+        return ResponseEntity.ok(
+                sellerService.getSalesByUserId(user.getId(), start, end, unit)
+        );
+    }
 }

--- a/back/src/main/java/org/kosa/tripTalk/seller/SellerRepository.java
+++ b/back/src/main/java/org/kosa/tripTalk/seller/SellerRepository.java
@@ -1,10 +1,9 @@
 package org.kosa.tripTalk.seller;
 
-import org.kosa.tripTalk.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface SellerRepository extends JpaRepository<Seller, Long> {
-
+public interface SellerRepository extends JpaRepository<Seller, Long>, SellerRepositoryCustom {
+	
 }

--- a/back/src/main/java/org/kosa/tripTalk/seller/SellerRepositoryCustom.java
+++ b/back/src/main/java/org/kosa/tripTalk/seller/SellerRepositoryCustom.java
@@ -1,0 +1,9 @@
+package org.kosa.tripTalk.seller;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface SellerRepositoryCustom {
+	// 단위(daily/monthly/yearly)에 따른 매출 통계 조회
+	List<?> getSalesByUnit(Long sellerId, LocalDate start, LocalDate end, String unit);
+}

--- a/back/src/main/java/org/kosa/tripTalk/seller/SellerRepositoryImpl.java
+++ b/back/src/main/java/org/kosa/tripTalk/seller/SellerRepositoryImpl.java
@@ -1,0 +1,101 @@
+package org.kosa.tripTalk.seller;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import org.kosa.tripTalk.exception.NotFoundException;
+import org.kosa.tripTalk.payment.QPayment;
+import org.kosa.tripTalk.product.QProduct;
+import org.springframework.stereotype.Repository;
+import static org.kosa.tripTalk.common.predicate.PredicateBuilder.*;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.StringTemplate;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class SellerRepositoryImpl implements SellerRepositoryCustom {
+	
+	private final JPAQueryFactory queryFactory;
+
+	@Override
+	public List<?> getSalesByUnit(Long sellerId, LocalDate start, LocalDate end, String unit) {
+		// 단위별로 매출 집계
+        return switch (unit.toLowerCase()) {
+            case "daily" -> getDailySales(sellerId, start, end);
+            case "monthly" -> getGroupedSales(sellerId, start, end, "month");
+            case "yearly" -> getGroupedSales(sellerId, start, end, "year");
+            default -> throw new NotFoundException("지원하지 않는 단위입니다: " + unit);
+        };
+    }
+
+	// 날짜별 결제 금액 합계 반환
+    private List<DailySaleDTO> getDailySales(Long sellerId, LocalDate start, LocalDate end) {
+        QPayment payment = QPayment.payment;
+        QProduct product = QProduct.product;
+
+        // 기간 조건
+        BooleanExpression dateCond = between(
+            payment.paymentDate,
+            start.atStartOfDay(),
+            end.plusDays(1).atStartOfDay()
+        );
+
+        // 결제일 단위로 각 날짜별 매출합 집계
+        return queryFactory
+            .select(Projections.constructor(
+                DailySaleDTO.class,
+                payment.paymentDate,
+                Expressions.numberTemplate(Long.class, "SUM({0})", payment.amount)
+            ))
+            .from(payment)
+            .join(payment.product, product)
+            .where(
+                payment.status.eq("SUCCESS"),
+                product.seller.id.eq(sellerId),
+                dateCond
+            )
+            .groupBy(payment.paymentDate)
+            .orderBy(payment.paymentDate.asc())
+            .fetch();
+    }
+
+    // 월별, 연도별 집계, unit 따라 월 또는 년 단위로 그룹핑
+    private List<GroupedSaleDTO> getGroupedSales(Long sellerId, LocalDate start, LocalDate end, String unit) {
+        QPayment payment = QPayment.payment;
+        QProduct product = QProduct.product;
+
+        BooleanExpression dateCond = between(
+            payment.paymentDate,
+            start.atStartOfDay(),
+            end.plusDays(1).atStartOfDay()
+        );
+
+        StringTemplate groupKey = switch (unit) {
+            case "month" -> Expressions.stringTemplate("TO_CHAR({0}, 'YYYY-MM')", payment.paymentDate);
+            case "year" -> Expressions.stringTemplate("TO_CHAR({0}, 'YYYY')", payment.paymentDate);
+            default -> throw new NotFoundException("지원하지 않는 단위입니다: " + unit);
+        };
+
+        return queryFactory
+            .select(Projections.constructor(
+                GroupedSaleDTO.class,
+                groupKey,
+                Expressions.numberTemplate(Long.class, "SUM({0})", payment.amount)
+            ))
+            .from(payment)
+            .join(payment.product, product)
+            .where(
+                payment.status.eq("SUCCESS"),
+                product.seller.id.eq(sellerId),
+                dateCond
+            )
+            .groupBy(groupKey)
+            .orderBy(groupKey.asc())
+            .fetch();
+    }
+}

--- a/back/src/main/java/org/kosa/tripTalk/seller/SellerService.java
+++ b/back/src/main/java/org/kosa/tripTalk/seller/SellerService.java
@@ -1,5 +1,9 @@
 package org.kosa.tripTalk.seller;
 
+import java.time.LocalDate;
+import java.util.List;
+
+import org.kosa.tripTalk.exception.NotFoundException;
 import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
@@ -8,4 +12,14 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class SellerService {
 	private final SellerRepository sellerRepository;
+	private final SellerRepositoryImpl sellerRepositoryImpl;
+
+     // 로그인한 사용자의 ID로 판매자를 조회하고,
+     // 해당 판매자의 기간별 매출을 단위에 따라 조회한다.
+    public List<?> getSalesByUserId(Long userId, LocalDate start, LocalDate end, String unit) {
+        Seller seller = sellerRepository.findById(userId)
+        		.orElseThrow(() -> new NotFoundException("판매자 정보를 찾을 수 없습니다."));
+
+        return sellerRepositoryImpl.getSalesByUnit(seller.getId(), start, end, unit);
+    }
 }

--- a/back/src/test/java/org/kosa/tripTalk/product/ProductServiceTest.java
+++ b/back/src/test/java/org/kosa/tripTalk/product/ProductServiceTest.java
@@ -168,6 +168,37 @@ class ProductServiceTest {
         assertThat(updated.getDiscountedPrice()).isEqualTo(120000);
         assertThat(updated.getDiscount().getName()).isEqualTo("20% 여름 할인");
     }
+    
+    @Test
+    @DisplayName("상품 목록 조회 시 할인 정보가 포함된다")
+    void getAllProducts_includesDiscountInfo() {
+        // given
+        DiscountDTO discount = createDiscountDTO(DiscountType.RATE, 0, 0.1, "10% 할인", 5);
+
+        ProductRequestDTO request = createProductRequest(
+            "서울 여행", "할인 있는 상품", 100000,
+            LocalDateTime.now().plusDays(3), LocalDateTime.now().plusDays(5)
+        ).toBuilder().discount(discount).build();
+
+        productService.create(request);
+
+        PageRequestDTO pageRequestDTO = new PageRequestDTO(1, 10, "price,asc");
+        Pageable pageable = pageRequestDTO.toPageable();
+        Search search = new Search(); // 전체 검색
+
+        // when
+        Page<ProductResponseDTO> result = productService.getAllProducts(pageable, search);
+
+        // then
+        assertThat(result.getContent()).hasSize(1);
+        ProductResponseDTO dto = result.getContent().get(0);
+
+        assertThat(dto.getTitle()).isEqualTo("서울 여행");
+        assertThat(dto.getDiscount()).isNotNull();
+        assertThat(dto.getDiscount().getDiscountType()).isEqualTo(DiscountType.RATE);
+        assertThat(dto.getDiscount().getName()).isEqualTo("10% 할인");
+        assertThat(dto.getDiscountedPrice()).isEqualTo(90000); // 10% 할인
+    }
 
     // ========== 공통 유틸 메서드 ==========
 

--- a/back/src/test/java/org/kosa/tripTalk/seller/SellerServiceTest.java
+++ b/back/src/test/java/org/kosa/tripTalk/seller/SellerServiceTest.java
@@ -1,0 +1,135 @@
+package org.kosa.tripTalk.seller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.kosa.tripTalk.category.Category;
+import org.kosa.tripTalk.category.CategoryRepository;
+import org.kosa.tripTalk.payment.Payment;
+import org.kosa.tripTalk.payment.PaymentRepository;
+import org.kosa.tripTalk.product.Product;
+import org.kosa.tripTalk.product.ProductRepository;
+import org.kosa.tripTalk.user.User;
+import org.kosa.tripTalk.user.UserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+@DisplayName("매출 조회 테스트")
+@SpringBootTest
+@Transactional
+@ActiveProfiles("test")
+class SellerServiceTest {
+	
+	@Autowired SellerService sellerService;
+    @Autowired SellerRepository sellerRepository;
+    @Autowired UserRepository userRepository;
+    @Autowired ProductRepository productRepository;
+    @Autowired PaymentRepository paymentRepository;
+    @Autowired CategoryRepository categoryRepository;
+
+	 private Long sellerId;
+
+	    @BeforeEach
+	    void setup() {
+	        // 판매자 회원
+	    	User user = userRepository.save(User.builder()
+	    		    .userId("seller1")
+	    		    .name("홍길동")
+	    		    .email("seller@example.com")
+	    		    .password("encoded-password")
+	    		    .nickname("판매자1")
+	    		    .phone("010-1234-5678")
+	    		    .role(User.Role.SELLER)
+	    		    .loginType("LOCAL")
+	    		    .emailVerified(true)
+	    		    .build());
+
+	        // 판매자
+	        Seller seller = sellerRepository.save(Seller.builder()
+	                .user(user)
+	                .userid(user.getUserId())
+	                .businessName("판매자1")
+	                .contact("010-1111-1111")
+	                .build());
+	        sellerId = seller.getId();
+	        
+	        Category category = categoryRepository.save(Category.builder()
+	        	    .kind("여행")
+	        	    .description("여행 관련 카테고리")
+	        	    .iconUrl("https://example.com/icon.png")
+	        	    .build());
+
+	        // 상품
+	        Product product = productRepository.save(Product.builder()
+	        	    .title("부산 여행")
+	        	    .description("부산 여행 상품 설명")
+	        	    .address("부산 해운대구")
+	        	    .price(100_000)
+	        	    .startDate(LocalDateTime.now().plusDays(1))
+	        	    .endDate(LocalDateTime.now().plusDays(5))
+	        	    .seller(seller)
+	        	    .category(category)
+	        	    .build());
+
+	        // 결제 성공
+	        paymentRepository.save(Payment.builder()
+	        	    .product(product)
+	        	    .user(user)
+	        	    .transactionId("TXN_SUCCESS_001")
+	        	    .paymentMethod("CARD")
+	        	    .amount(100_000)
+	        	    .status("SUCCESS")
+	        	    .paymentDate(LocalDateTime.now().minusDays(1))
+	        	    .build());
+
+	        // 결제 실패 (무시되어야 함)
+	        paymentRepository.save(Payment.builder()
+	        	    .product(product)
+	        	    .user(user)
+	        	    .transactionId("TXN_FAIL_001")
+	        	    .paymentMethod("CARD")
+	        	    .amount(100_000)
+	        	    .status("FAILED")
+	        	    .paymentDate(LocalDateTime.now())
+	        	    .build());
+	    }
+
+	    @Test
+	    @DisplayName("판매자 매출 일별 조회 성공")
+	    void getSalesByDay_success() {
+	        LocalDate start = LocalDate.now().minusDays(7);
+	        LocalDate end = LocalDate.now();
+
+	        List<?> result = sellerService.getSalesByUserId(sellerId, start, end, "daily");
+
+	        assertThat(result).hasSize(1);
+	        assertThat(result.get(0)).isInstanceOf(DailySaleDTO.class);
+
+	        DailySaleDTO dto = (DailySaleDTO) result.get(0);
+	        assertThat(dto.amount()).isEqualTo(100_000L);
+	    }
+
+	    @Test
+	    @DisplayName("판매자 매출 월별 조회 성공")
+	    void getSalesByMonth_success() {
+	        LocalDate start = LocalDate.now().withDayOfMonth(1);
+	        LocalDate end = LocalDate.now();
+
+	        List<?> result = sellerService.getSalesByUserId(sellerId, start, end, "monthly");
+
+	        assertThat(result).hasSize(1);
+	        assertThat(result.get(0)).isInstanceOf(GroupedSaleDTO.class);
+
+	        GroupedSaleDTO dto = (GroupedSaleDTO) result.get(0);
+	        assertThat(dto.amount()).isEqualTo(100_000L);
+	    }
+
+}


### PR DESCRIPTION
## 🔧 작업 내용  
- 판매자 매출 기간별 조회 기능 구현  
  - 일별(Daily), 월별(Monthly) 단위로 매출 집계  
  - QueryDSL을 사용하여 동적 쿼리 구성  
- DTO (DailySaleDTO, GroupedSaleDTO) 정의 및 Q클래스 생성  
- SellerRepositoryCustom / Impl 구조로 분리하여 책임 명확화  
- SellerService 단에서 매출 조회 기능 호출 및 응답 처리  
- 매출 조회 단위에 따른 switch 분기 처리 추가  
- 관련 단위 테스트 작성

## 📌 참고 사항  
- Payment → Product → Seller 경로를 기준으로 매출 집계  
- LocalDate 기준으로 start ~ end 범위 조회 가능  
- 단위별 로직이 나뉘므로 확장/유지보수 시 함수 단위 분리 확인  
- QueryDSL 버전에 따라 `StringTemplate` 날짜 변환 처리 유의
